### PR TITLE
[fix] : 가장 많이 되는 시간 조회 시, 6번째 항목에서 시간이 끊기는 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -229,17 +229,22 @@ public class EventService {
         List<GetMostPossibleTime> mostPossibleTimes = new ArrayList<>();
         GetMostPossibleTime previousTime = null;
 
+        boolean stopFlag = false;
         for (Map.Entry<Schedule, List<String>> entry : scheduleToNamesMap.entrySet()) {
             Schedule schedule = entry.getKey();
             List<String> curNames = entry.getValue();
 
             if (curNames.size() == mostPossibleCnt) {
-                // 이전 시간대와 병합 가능한 경우
                 if (canMergeWithPrevious(previousTime, schedule, curNames, category)) {
-                    // 종료 시간을 더해 업데이트
+                    // 이전 시간대와 병합 가능한 경우
                     previousTime = previousTime.updateEndTime(schedule.getTime());
-                    mostPossibleTimes.set(mostPossibleTimes.size() - 1, previousTime);
+                    mostPossibleTimes.set(mostPossibleTimes.size() - 1, previousTime); // 종료 시간을 더해 업데이트
                 } else {
+                    // 새로운 시간대를 추가하는 경우
+                    if (mostPossibleTimes.size() == MAX_MOST_POSSIBLE_TIMES_SIZE) {
+                        // 6개를 찾았을 시 종료
+                        stopFlag = true;
+                    }
                     List<String> impossibleNames = allMembersName.stream()
                             .filter(name -> !curNames.contains(name))
                             .toList();
@@ -250,8 +255,7 @@ public class EventService {
                     previousTime = newTime;
                 }
             }
-
-            if (mostPossibleTimes.size() == MAX_MOST_POSSIBLE_TIMES_SIZE) {
+            if (stopFlag) {
                 break;
             }
         }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 문제 원인

```java
...

 for (Map.Entry<Schedule, List<String>> entry : scheduleToNamesMap.entrySet()) {
            Schedule schedule = entry.getKey();
            List<String> curNames = entry.getValue();

            if (curNames.size() == mostPossibleCnt) {
                // 이전 시간대와 병합 가능한 경우
                if (canMergeWithPrevious(previousTime, schedule, curNames, category)) {
                    // 종료 시간을 더해 업데이트
                    previousTime = previousTime.updateEndTime(schedule.getTime());
                    mostPossibleTimes.set(mostPossibleTimes.size() - 1, previousTime);
                } else {
                    List<String> impossibleNames = allMembersName.stream()
                            .filter(name -> !curNames.contains(name))
                            .toList();

                    // 새로운 시간대를 추가
                    GetMostPossibleTime newTime = createMostPossibleTime(schedule, curNames, impossibleNames, category);
                    mostPossibleTimes.add(newTime);
                    previousTime = newTime;
                }
            }

            if (mostPossibleTimes.size() == MAX_MOST_POSSIBLE_TIMES_SIZE) {
                break;
            }
        }

...
```

- 6번째 시간대를 처음 추가하는 경우에 종료 조건문에 걸려 바로 반복문이 종료됨. 때문에 30분에서 끊기고 그 이후가 이어지지 않았음
- 종료 조건문의 위치를 바꾸는 것으로 해결함

### 해결 전

<img width="767" alt="스크린샷 2024-12-01 오후 11 42 55" src="https://github.com/user-attachments/assets/ef793343-a4c8-4e33-93cb-5f536acd1616">

<img width="349" alt="스크린샷 2024-12-01 오후 11 43 03" src="https://github.com/user-attachments/assets/cea029e4-839f-4074-9f66-4e9e853fa4c5">

- `16:00 - 17:00` 이 아닌, `16:00 - 16:30` 으로 나오는 모습

### 해결 후

<img width="348" alt="스크린샷 2024-12-02 오전 12 25 18" src="https://github.com/user-attachments/assets/86845f16-40f2-4e6a-9555-999676643169">

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요


- Resolves : #123

---

## 🎸 기타 사항 or 추가 코멘트