### PR TITLE
[fix] : 요일 별 고정 스케줄 조회 시, 빠른 시간 순으로 정렬되지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/service/FixedEventService.java
+++ b/src/main/java/side/onetime/service/FixedEventService.java
@@ -15,6 +15,7 @@ import side.onetime.repository.FixedEventRepository;
 import side.onetime.util.DateUtil;
 import side.onetime.util.JwtUtil;
 
+import java.util.Comparator;
 import java.util.List;
 
 
@@ -80,10 +81,11 @@ public class FixedEventService {
      * 요일별 고정 이벤트 조회 메서드.
      *
      * 특정 요일에 해당하는 고정 이벤트 목록을 조회합니다.
+     * startTime을 기준으로 오름차순 정렬하여 반환합니다.
      *
      * @param authorizationHeader 인증 토큰
      * @param day 조회할 요일 (예: "mon", "tue" 등)
-     * @return 고정 이벤트 목록
+     * @return 고정 이벤트 목록 (startTime 기준 오름차순 정렬)
      */
     @Transactional(readOnly = true)
     public List<FixedEventByDayResponse> getFixedEventByDay(String authorizationHeader, String day) {
@@ -102,6 +104,7 @@ public class FixedEventService {
                             DateUtil.addThirtyMinutes(endTime)
                     );
                 })
+                .sorted(Comparator.comparing(FixedEventByDayResponse::startTime))
                 .toList();
     }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 요일 별 고정 스케줄 조회 시, 빠른 시간 순으로 정렬되지 않는 문제를 해결하였습니다.

### 기존

<img width="378" alt="스크린샷 2024-12-10 오후 10 14 19" src="https://github.com/user-attachments/assets/d888b7fa-c24d-4ae9-9df9-f6e115f1c21c">

### 변경 후

<img width="380" alt="image" src="https://github.com/user-attachments/assets/4559ab04-35c2-4683-9df9-fc73df336b20">

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #135 

---

## 🎸 기타 사항 or 추가 코멘트