### PR TITLE
[fix] : 빈 스케줄 등록과 관련한 에러들을 해결한다

### DIFF
--- a/src/main/java/side/onetime/domain/EventParticipation.java
+++ b/src/main/java/side/onetime/domain/EventParticipation.java
@@ -36,4 +36,8 @@ public class EventParticipation extends BaseEntity {
         this.user = user;
         this.eventStatus = eventStatus;
     }
+
+    public void updateEventStatus(EventStatus eventStatus) {
+        this.eventStatus = eventStatus;
+    }
 }

--- a/src/main/java/side/onetime/domain/enums/EventStatus.java
+++ b/src/main/java/side/onetime/domain/enums/EventStatus.java
@@ -2,5 +2,6 @@ package side.onetime.domain.enums;
 
 public enum EventStatus {
     CREATOR,  // 이벤트 생성자
-    PARTICIPANT  // 이벤트 참여자
+    PARTICIPANT,  // 이벤트 참여자
+    CREATOR_AND_PARTICIPANT  // 이벤트 생성 및 참여자
 }

--- a/src/main/java/side/onetime/dto/event/response/GetEventResponse.java
+++ b/src/main/java/side/onetime/dto/event/response/GetEventResponse.java
@@ -28,7 +28,7 @@ public record GetEventResponse(
                 event.getEndTime(),
                 event.getCategory(),
                 ranges,
-                EventStatus.PARTICIPANT == eventStatus ? eventStatus : EventStatus.CREATOR
+                EventStatus.PARTICIPANT == eventStatus || eventStatus == null ? eventStatus : EventStatus.CREATOR
         );
     }
 }

--- a/src/main/java/side/onetime/dto/event/response/GetEventResponse.java
+++ b/src/main/java/side/onetime/dto/event/response/GetEventResponse.java
@@ -28,7 +28,7 @@ public record GetEventResponse(
                 event.getEndTime(),
                 event.getCategory(),
                 ranges,
-                eventStatus
+                EventStatus.PARTICIPANT == eventStatus ? eventStatus : EventStatus.CREATOR
         );
     }
 }

--- a/src/main/java/side/onetime/exception/status/EventParticipationErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/EventParticipationErrorStatus.java
@@ -10,7 +10,7 @@ import side.onetime.global.common.dto.ErrorReasonDto;
 @RequiredArgsConstructor
 public enum EventParticipationErrorStatus implements BaseErrorCode {
     _NOT_FOUND_EVENT_PARTICIPATION(HttpStatus.NOT_FOUND, "EVENT-PARTICIPATION-001", "이벤트 참여 여부를 찾을 수 없습니다."),
-    _IS_NOT_USERS_CREATED_EVENT_PARTICIPATION(HttpStatus.BAD_REQUEST, "EVENT-PARTICIPATION-002", "해당 이벤트의 생성자가 아닙니다."),
+    _IS_NOT_AUTHORIZED_EVENT_PARTICIPATION(HttpStatus.BAD_REQUEST, "EVENT-PARTICIPATION-002", "해당 이벤트의 생성자 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/repository/MemberRepository.java
+++ b/src/main/java/side/onetime/repository/MemberRepository.java
@@ -15,14 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEventAndNameAndPin(Event event, String name, String pin);
     Optional<Member> findByMemberId(UUID memberId);
 
-    @Query("SELECT m FROM Member m " +
-            "JOIN FETCH m.selections s " +
-            "JOIN FETCH s.schedule sch " +
-            "WHERE m.event = :event")
-    List<Member> findAllWithSelectionsAndSchedulesByEvent(@Param("event") Event event);
-
-    @Query("SELECT m FROM Member m JOIN FETCH m.selections WHERE m.memberId = :memberId")
-    Optional<Member> findByMemberIdWithSelections(@Param("memberId") UUID memberId);
+    List<Member> findAllByEvent(Event event);
 
     @Query("SELECT m FROM Member m " +
             "JOIN FETCH m.selections s " +

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -85,9 +85,9 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(createDayScheduleRequest.eventId()))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
         User user = jwtUtil.getUserFromHeader(authorizationHeader);
-        // 참여 정보가 없는 경우 참여자로 저장
         EventParticipation eventParticipation = eventParticipationRepository.findByUserAndEvent(user, event);
         if (eventParticipation == null) {
+            // 참여 정보가 없는 경우 참여자로 저장
             eventParticipationRepository.save(
                     EventParticipation.builder()
                             .user(user)
@@ -95,6 +95,9 @@ public class ScheduleService {
                             .eventStatus(EventStatus.PARTICIPANT)
                             .build()
             );
+        } else if (EventStatus.CREATOR == eventParticipation.getEventStatus()) {
+            // 생성자인 경우 생성자 & 참여자로 변경
+            eventParticipation.updateEventStatus(EventStatus.CREATOR_AND_PARTICIPANT);
         }
 
         List<DaySchedule> daySchedules = createDayScheduleRequest.daySchedules();
@@ -172,9 +175,9 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(createDateScheduleRequest.eventId()))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
         User user = jwtUtil.getUserFromHeader(authorizationHeader);
-        // 참여 정보가 없는 경우 참여자로 저장
         EventParticipation eventParticipation = eventParticipationRepository.findByUserAndEvent(user, event);
         if (eventParticipation == null) {
+            // 참여 정보가 없는 경우 참여자로 저장
             eventParticipationRepository.save(
                     EventParticipation.builder()
                             .user(user)
@@ -182,6 +185,9 @@ public class ScheduleService {
                             .eventStatus(EventStatus.PARTICIPANT)
                             .build()
             );
+        } else if (EventStatus.CREATOR == eventParticipation.getEventStatus()) {
+            // 생성자인 경우 생성자 & 참여자로 변경
+            eventParticipation.updateEventStatus(EventStatus.CREATOR_AND_PARTICIPANT);
         }
 
         List<DateSchedule> dateSchedules = createDateScheduleRequest.dateSchedules();

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -231,7 +231,7 @@ public class ScheduleService {
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
         // 이벤트에 참여하는 모든 멤버
-        List<Member> members = memberRepository.findAllWithSelectionsAndSchedulesByEvent(event);
+        List<Member> members = memberRepository.findAllByEvent(event);
 
         // 이벤트에 참여하는 모든 참여자 목록
         GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
@@ -294,7 +294,7 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-        Member member = memberRepository.findByMemberIdWithSelections(UUID.fromString(memberId))
+        Member member = memberRepository.findByMemberId(UUID.fromString(memberId))
                 .orElseThrow(() -> new CustomException(MemberErrorStatus._NOT_FOUND_MEMBER));
 
         Map<String, List<Selection>> groupedSelectionsByDay = member.getSelections().stream()
@@ -356,7 +356,7 @@ public class ScheduleService {
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
         // 이벤트에 참여하는 모든 멤버
-        List<Member> members = memberRepository.findAllWithSelectionsAndSchedulesByEvent(event);
+        List<Member> members = memberRepository.findAllByEvent(event);
 
         // 이벤트에 참여하는 모든 참여자 목록
         GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
@@ -419,7 +419,7 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-        Member member = memberRepository.findByMemberIdWithSelections(UUID.fromString(memberId))
+        Member member = memberRepository.findByMemberId(UUID.fromString(memberId))
                 .orElseThrow(() -> new CustomException(MemberErrorStatus._NOT_FOUND_MEMBER));
 
         Map<String, List<Selection>> groupedSelectionsByDate = member.getSelections().stream()


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이벤트 생성자이지만, 빈 스케줄을 등록하는 경우를 고려하여 `CREATOR_AND_PARTICIPANT` 필드를 추가하여 구분하였습니다.
- 참여 목록에 `CREATOR` 와 `PARTICIPANT` 둘 다 들어가는 방법도 고려하였지만, 변경할 코드가 너무 많아진다고 판단하여 위 방법을 택하였습니다.
- 이벤트 수정  & 삭제 권한은 `CREATOR` 와 `CREATOR_AND_PARTICIPANT` 에게만 주어집니다.
- 전체 스케줄 (날짜 & 요일) 조회 시, 빈 스케줄을 등록한 멤버는 제외되었던 문제를 해결하였습니다.
- 개인 스케줄 (날짜 & 요일) 조회 시, 빈 스케줄을 등록한 멤버는 404 에러가 발생하였던 문제를 해결하였습니다.
---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #157 

---

## 🎸 기타 사항 or 추가 코멘트