### PR TITLE
[fix] : 이벤트 범위 수정 후 데이터가 즉시 반영되도록 하여 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/global/config/SwaggerConfig.java
+++ b/src/main/java/side/onetime/global/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
         OpenAPI openAPI = new OpenAPI()
                 .info(new Info()
                         .title("OneTime API Documentation")
-                        .version("1.3.0")
+                        .version("v1.4.4")
                         .description("Spring REST Docs with Swagger UI.")
                         .contact(new Contact()
                         .name("Sangho Han")

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -454,7 +454,11 @@ public class EventService {
 
         updateEventTitle(event, modifyUserCreatedEventRequest.title());
         updateEventRanges(event, event.getSchedules(), modifyUserCreatedEventRequest.ranges(), modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
-        updateEventTimes(event, event.getSchedules(), modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
+
+        // 변경된 범위에 따른 새로운 스케줄 목록
+        List<Schedule> newSchedules = scheduleRepository.findAllByEvent(event)
+                .orElseThrow(() -> new CustomException(ScheduleErrorStatus._NOT_FOUND_ALL_SCHEDULES));
+        updateEventTimes(event, newSchedules, modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
     }
 
     /**

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -502,6 +502,7 @@ public class EventService {
                 createAndSaveDaySchedules(event, rangesToCreate, newStartTime, newEndTime);
             }
         }
+        scheduleRepository.flush();
     }
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -108,7 +108,7 @@ springdoc:
     operations-sorter: alpha
   api-docs:
     path: /v3/api-docs
-  show-actuator: true
+  show-actuator: false
 
 qr:
   event-base-url: ${QR_EVENT_BASE_URL}
@@ -116,7 +116,7 @@ qr:
 management:
   endpoint:
     health:
-      show-details: never # 상세 정보 숨기기
+      show-details: never
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스웨거 관련 수정 사항

- 스웨거 API 문서의 버전을 `v1.4.4`로 수정하였습니다.
- Actuator 관련 API가 스웨거에 나오지 않도록 변경하였습니다.

### 이벤트 수정 문제 해결 1

- 이벤트를 수정할 때 범위와 시간대를 동시에 변경하면, 범위가 줄어들지 않는 경우가 있었습니다.
- 로직 상 범위를 먼저 수정하고, 시간대를 수정하게 되는데 동일 트랜잭션 내에 있어 수정된 부분이 반영되지 않은 채로 새로운 시간대를 추가하였기 때문입니다.
- 범위를 수정한 후 `flush()`를 호출해 문제를 해결하였습니다. 

### 이벤트 수정 문제 해결 2
- `flush()`를 추가하였음에도 문제가 해결되지 않았는데, 이는 기존 로직에서 `event.getSchedules()`를 그대로 사용했기 때문입니다.
- 때문에 아래와 같이 코드를 수정하여 문제를 최종적으로 해결하였습니다.

```java
// 변경된 범위에 따른 새로운 스케줄 목록
List<Schedule> newSchedules = scheduleRepository.findAllByEvent(event)
                .orElseThrow(() -> new CustomException(ScheduleErrorStatus._NOT_FOUND_ALL_SCHEDULES));
updateEventTimes(event, newSchedules, modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
```


---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #162 

---

## 🎸 기타 사항 or 추가 코멘트

- `flush()` 호출로 해결한 것이 좋은 방법인지 조금 더 알아보아야할 것 같습니다.
