### PR TITLE
[feat] : 유저 닉네임 & 이벤트 제목의 길이 제한을 50자로 늘린다

### DIFF
--- a/src/main/java/side/onetime/domain/Event.java
+++ b/src/main/java/side/onetime/domain/Event.java
@@ -24,7 +24,7 @@ public class Event extends BaseEntity {
     @Column(name = "events_uuid", columnDefinition = "BINARY(16)", unique = true)
     private UUID eventId;
 
-    @Column(name = "title", nullable = false, length = 30)
+    @Column(name = "title", nullable = false, length = 50)
     private String title;
 
     @Column(name = "start_time", nullable = false)

--- a/src/main/java/side/onetime/domain/User.java
+++ b/src/main/java/side/onetime/domain/User.java
@@ -26,7 +26,7 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, length = 50)
     private String email;
 
-    @Column(name = "nickname", nullable = false, length = 30)
+    @Column(name = "nickname", nullable = false, length = 50)
     private String nickname;
 
     @Column(name = "provider", nullable = false, length = 50)

--- a/src/main/java/side/onetime/dto/event/request/CreateEventRequest.java
+++ b/src/main/java/side/onetime/dto/event/request/CreateEventRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import side.onetime.domain.Event;
 import side.onetime.domain.enums.Category;
 
@@ -14,11 +15,17 @@ import java.util.UUID;
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CreateEventRequest(
-        @NotBlank(message = "제목은 필수 값입니다.") String title,
-        @NotBlank(message = "시작 시간은 필수 값입니다.") String startTime,
-        @NotBlank(message = "종료 시간은 필수 값입니다.") String endTime,
-        @NotNull(message = "카테고리는 필수 값입니다.") Category category,
-        @NotNull(message = "설문 범위는 필수 값입니다.") List<String> ranges
+        @NotBlank(message = "제목은 필수 값입니다.")
+        @Size(max = 50, message = "제목은 최대 50자까지 가능합니다.")
+        String title,
+        @NotBlank(message = "시작 시간은 필수 값입니다.")
+        String startTime,
+        @NotBlank(message = "종료 시간은 필수 값입니다.")
+        String endTime,
+        @NotNull(message = "카테고리는 필수 값입니다.")
+        Category category,
+        @NotNull(message = "설문 범위는 필수 값입니다.")
+        List<String> ranges
 ) {
     public Event toEntity() {
         return Event.builder()

--- a/src/main/java/side/onetime/dto/user/request/OnboardUserRequest.java
+++ b/src/main/java/side/onetime/dto/user/request/OnboardUserRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import side.onetime.domain.enums.Language;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -13,6 +14,7 @@ public record OnboardUserRequest(
         @NotBlank(message = "레지스터 토큰은 필수 값입니다.")
         String registerToken,
         @NotBlank(message = "닉네임은 필수 값입니다.")
+        @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
         String nickname,
         @NotNull(message = "서비스 이용약관 동의여부는 필수 값입니다.")
         Boolean servicePolicyAgreement,

--- a/src/main/java/side/onetime/dto/user/request/UpdateUserProfileRequest.java
+++ b/src/main/java/side/onetime/dto/user/request/UpdateUserProfileRequest.java
@@ -3,11 +3,13 @@ package side.onetime.dto.user.request;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.Size;
 import side.onetime.domain.enums.Language;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UpdateUserProfileRequest(
+        @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
         String nickname,
         Language language
 ) {

--- a/src/main/java/side/onetime/exception/status/UserErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/UserErrorStatus.java
@@ -10,9 +10,8 @@ import side.onetime.global.common.dto.ErrorReasonDto;
 @RequiredArgsConstructor
 public enum UserErrorStatus implements BaseErrorCode {
     _NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER-001", "유저를 찾을 수 없습니다."),
-    _NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-002", "닉네임 길이 제한을 초과했습니다."),
-    _NOT_FOUND_USER_BY_USERNAME(HttpStatus.NOT_FOUND, "USER-003", "username으로 user를 찾을 수 없습니다."),
-    _NOT_FOUND_USER_BY_USERID(HttpStatus.NOT_FOUND, "USER-004", "userId로 user를 찾을 수 없습니다."),
+    _NOT_FOUND_USER_BY_USERNAME(HttpStatus.NOT_FOUND, "USER-002", "username으로 user를 찾을 수 없습니다."),
+    _NOT_FOUND_USER_BY_USERID(HttpStatus.NOT_FOUND, "USER-003", "userId로 user를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 유저 닉네임 & 이벤트 제목 길이 제한 변경

- 영어권 국가 유저를 고려하여 닉네임 & 이벤트 제목 길이 제한을 50자로 늘렸습니다.
- 이는 유효성 검증을 통해 확인하기에, 기존에 서비스 단에 있던 불필요한 검증 로직 및 코드를 제거하였습니다.

### 중복 코드 제거

- 이벤트 생성 시, 로그인 & 비로그인 유저로 나뉘어져 있어 중복되는 코드가 많았습니다.
- 중복 코드를 통합하여 간결성 및 가독성을 향상시켰습니다.

### 불필요한 트랜잭셔널 제거

- 부모 메서드에서 트랜잭셔널을 적용하였는데, 자식 메서드에서도 중복으로 적용중이었기에 불필요한 트랜잭셔널을 제거하였습니다.
- 이에 protected 였던 메서드들을 private으로 변경하였습니다.

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #177

---

## 🎸 기타 사항 or 추가 코멘트