### PR TITLE
[fix] : 이름이 아닌 참여 여부를 통해서 이벤트 참여 유저를 파악한다

### DIFF
--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -237,11 +237,11 @@ public class ScheduleService {
         GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
         List<String> participantNames = getParticipantsResponse.names();
 
-        // 이벤트에 참여하는 모든 유저
+        // 이벤트에 참여하는 모든 유저 (CREATOR가 아닌 경우만 포함)
         List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEvent(event);
         List<User> users = eventParticipations.stream()
+                .filter(eventParticipation -> eventParticipation.getEventStatus() != EventStatus.CREATOR)
                 .map(EventParticipation::getUser)
-                .filter(user -> participantNames.contains(user.getNickname())) // 유저가 참여자 목록에 있는지 확인
                 .toList();
 
         List<PerDaySchedulesResponse> perDaySchedulesResponses = new ArrayList<>();
@@ -362,11 +362,11 @@ public class ScheduleService {
         GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
         List<String> participantNames = getParticipantsResponse.names();
 
-        // 이벤트에 참여하는 모든 유저
+        // 이벤트에 참여하는 모든 유저 (CREATOR가 아닌 경우만 포함)
         List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEvent(event);
         List<User> users = eventParticipations.stream()
+                .filter(eventParticipation -> eventParticipation.getEventStatus() != EventStatus.CREATOR)
                 .map(EventParticipation::getUser)
-                .filter(user -> participantNames.contains(user.getNickname())) // 유저가 참여자 목록에 있는지 확인
                 .toList();
 
         List<PerDateSchedulesResponse> perDateSchedulesResponses = new ArrayList<>();


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제

<img width="895" alt="image" src="https://github.com/user-attachments/assets/15beb4eb-a91e-465f-b52b-c6f5d8b3b400" />

- 이벤트 생성자(로그인)와 동일한 이름의 멤버(비로그인)로 스케줄을 등록하면, 생성자까지 함께 조회되는 문제가 있었습니다.


### ✅ 해결

<img width="864" alt="image" src="https://github.com/user-attachments/assets/f115a389-4eb2-45aa-a0fd-cf68e981f14f" />

- 기존에는 스케줄을 조회할 때, 이벤트 참여 유저를 현재 참여 목록에 있는 `이름`으로 구분했기에 발생한 문제였습니다.
- 이를 이름이 아닌, event_status를 통해 필터링함으로써 문제를 해결하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #184 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
