### PR TITLE
[feat] : 불가능 인원 계산 로직을 변경하여 유저 & 멤버 동명이인 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -357,9 +357,16 @@ public class EventService {
                         // 6개를 찾았을 시 종료
                         break;
                     }
-                    List<String> impossibleNames = allMembersName.stream()
-                            .filter(name -> !curNames.contains(name))
-                            .toList();
+                    List<String> impossibleNames = new ArrayList<>();
+                    // 유저, 멤버 동명이인을 고려하기 위함
+                    List<String> curNamesCopy = new ArrayList<>(curNames);
+                    for (String name : allMembersName) {
+                        if (curNamesCopy.contains(name)) {
+                            curNamesCopy.remove(name);
+                        } else {
+                            impossibleNames.add(name);
+                        }
+                    }
 
                     // 새로운 시간대를 추가
                     GetMostPossibleTime newTime = createMostPossibleTime(schedule, curNames, impossibleNames, category);

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -255,8 +255,9 @@ public class EventService {
         GetParticipantsResponse getParticipantsResponse = getParticipants(eventId);
         List<String> participantNames = getParticipantsResponse.names();
 
-        // 유저 필터링: 참여자 목록에 있는 유저만 포함
+        // 유저 필터링: CREATOR가 아닌 경우에만 포함
         List<String> allUserNicknames = eventParticipations.stream()
+                .filter(ep -> ep.getEventStatus() != EventStatus.CREATOR)
                 .map(EventParticipation::getUser)
                 .map(User::getNickname)
                 .filter(participantNames::contains)


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제

<img width="892" alt="image" src="https://github.com/user-attachments/assets/8bc3b4db-3c85-469d-af48-231c411f90ad" />

- 기존에는 동명이인의 유저 & 멤버가 불가능 인원 목록에서 공존하지 못 하는 문제가 있었습니다.
- 이는 불가능 인원을 집계할 때 **단순히 가능 인원에 포함하지 않은 경우에만 추가했기 때문**입니다.

### ✅ 해결

<img width="886" alt="image" src="https://github.com/user-attachments/assets/2d7208fb-2633-4e84-9e57-109f75a360be" />

- 그렇기에 전체 인원에서 가능 인원을 제거한 나머지를 불가능 인원으로 집계하는 방식으로 로직을 수정하여 문제를 해결했습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #188 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
