### PR TITLE
[fix] : Filter 단계에서의 예외 처리 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/exception/status/UserErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/UserErrorStatus.java
@@ -12,6 +12,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     _NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER-001", "유저를 찾을 수 없습니다."),
     _NOT_FOUND_USER_BY_USERNAME(HttpStatus.NOT_FOUND, "USER-002", "username으로 user를 찾을 수 없습니다."),
     _NOT_FOUND_USER_BY_USERID(HttpStatus.NOT_FOUND, "USER-003", "userId로 user를 찾을 수 없습니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "USER-004", "인증된 사용자가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/global/filter/JwtFilter.java
+++ b/src/main/java/side/onetime/global/filter/JwtFilter.java
@@ -34,21 +34,19 @@ public class JwtFilter extends OncePerRequestFilter {
      * @throws IOException      입출력 예외 발생 시
      */
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try {
-            if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
-                filterChain.doFilter(request, response);
-                return;
-            }
-            String token = jwtUtil.getTokenFromHeader(request.getHeader("Authorization"));
-            jwtUtil.validateToken(token);
-            Long userId = jwtUtil.getClaimFromToken(token, "userId", Long.class);
-            setAuthentication(userId);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-        } catch (Exception e) {
-            log.error("JWT validation failed: " + e.getMessage());
-            SecurityContextHolder.clearContext();
+        if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        String token = jwtUtil.getTokenFromHeader(request.getHeader("Authorization"));
+        jwtUtil.validateToken(token);
+        Long userId = jwtUtil.getClaimFromToken(token, "userId", Long.class);
+        setAuthentication(userId);
+
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/side/onetime/service/TokenService.java
+++ b/src/main/java/side/onetime/service/TokenService.java
@@ -49,7 +49,6 @@ public class TokenService {
         String newRefreshToken = jwtUtil.generateRefreshToken(userId);
         refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
 
-        log.info("토큰 재발행에 성공하였습니다.");
         return ReissueTokenResponse.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/side/onetime/util/UserAuthorizationUtil.java
+++ b/src/main/java/side/onetime/util/UserAuthorizationUtil.java
@@ -3,6 +3,8 @@ package side.onetime.util;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import side.onetime.auth.dto.CustomUserDetails;
+import side.onetime.exception.CustomException;
+import side.onetime.exception.status.UserErrorStatus;
 
 public class UserAuthorizationUtil {
 
@@ -20,7 +22,11 @@ public class UserAuthorizationUtil {
      */
     public static Long getLoginUserId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof CustomUserDetails userDetails)) {
+            throw new CustomException(UserErrorStatus._UNAUTHORIZED);
+        }
         return userDetails.getId();
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제
- 액세스 토큰이 만료되어 검증 과정에서 발생되는 예외를 JwtFilter에서 Catch함으로써 전역예외처리가 제대로 작동하지 않았습니다.
- 이후 전역 예외 처리를 적용하고자 하였지만, `GlobalExceptionHandler`는 디스패처 서블렛 이후에 작동하므로 처리할 수 없었습니다.

### ✅ 해결
- 로직을 방어적으로 변경하였습니다.
- JwtFilter 내에서, 즉 Filter 단계에서 커스텀 에러를 처리할 수 있는 기능을 추가하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #216

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

[작성한 블로그 글](https://velog.io/@hsh111366/트러블슈팅-Filter-단계에서의-예외-처리)
