### PR TITLE
[feat] : 참여한 이벤트 조회 API의 성능을 개선한다

### DIFF
--- a/src/main/java/side/onetime/domain/Event.java
+++ b/src/main/java/side/onetime/domain/Event.java
@@ -59,7 +59,9 @@ public class Event extends BaseEntity {
     }
 
     public void updateTitle(String title) {
-        this.title = title;
+        if (title != null) {
+            this.title = title;
+        }
     }
 
     public void updateStartTime(String startTime) {

--- a/src/main/java/side/onetime/repository/EventParticipationRepository.java
+++ b/src/main/java/side/onetime/repository/EventParticipationRepository.java
@@ -1,6 +1,8 @@
 package side.onetime.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import side.onetime.domain.Event;
 import side.onetime.domain.EventParticipation;
 import side.onetime.domain.User;
@@ -12,7 +14,12 @@ public interface EventParticipationRepository extends JpaRepository<EventPartici
 
     List<EventParticipation> findAllByEvent(Event event);
 
-    List<EventParticipation> findAllByUser(User user);
+    @Query("""
+    SELECT ep FROM EventParticipation ep
+    JOIN FETCH ep.event
+    WHERE ep.user = :user
+    """)
+    List<EventParticipation> findAllByUserWithEvent(@Param("user") User user);
 
     EventParticipation findByUserAndEvent(User user, Event event);
 

--- a/src/main/java/side/onetime/repository/EventRepository.java
+++ b/src/main/java/side/onetime/repository/EventRepository.java
@@ -1,6 +1,8 @@
 package side.onetime.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import side.onetime.domain.Event;
 import side.onetime.repository.custom.EventRepositoryCustom;
 
@@ -10,9 +12,17 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event,Long>, EventRepositoryCustom {
+
     Optional<Event> findByEventId(UUID eventId);
 
     boolean existsByEventId(UUID eventId);
 
     List<Event> findByCreatedDateBefore(LocalDateTime twoWeeksAgo);
+
+    @Query("""
+    SELECT e FROM Event e
+    LEFT JOIN FETCH e.members
+    WHERE e.eventId = :eventId
+    """)
+    Optional<Event> findByEventIdWithMembers(@Param("eventId") UUID eventId);
 }

--- a/src/main/java/side/onetime/repository/SelectionRepository.java
+++ b/src/main/java/side/onetime/repository/SelectionRepository.java
@@ -8,10 +8,37 @@ import side.onetime.domain.*;
 import java.util.List;
 
 public interface SelectionRepository extends JpaRepository<Selection, Long> {
+
     void deleteAllByMember(Member member);
+
     void deleteAllByUserAndScheduleIn(User user, List<Schedule> schedules);
-    @Query("SELECT s FROM Selection s JOIN FETCH s.schedule sc WHERE sc.event = :event")
+
+    @Query("""
+        SELECT s FROM Selection s
+        JOIN FETCH s.schedule sc
+        WHERE sc.event = :event
+    """)
     List<Selection> findAllSelectionsByEvent(@Param("event") Event event);
-    @Query("SELECT COUNT(s) > 0 FROM Selection s WHERE s.user = :user AND s.schedule.event = :event")
+
+    @Query("""
+        SELECT COUNT(s) > 0 FROM Selection s
+        WHERE s.user = :user
+        AND s.schedule.event = :event
+    """)
     boolean existsByUserAndEventSchedules(@Param("user") User user, @Param("event") Event event);
+
+    @Query("""
+        SELECT s FROM Selection s
+        JOIN FETCH s.schedule sc
+        WHERE s.member = :member
+    """)
+    List<Selection> findAllByMemberWithSchedule(@Param("member") Member member);
+
+    @Query("""
+        SELECT s FROM Selection s
+        JOIN FETCH s.schedule sc
+        JOIN FETCH sc.event
+        WHERE s.user = :user
+    """)
+    List<Selection> findAllByUserWithScheduleAndEvent(@Param("user") User user);
 }

--- a/src/main/java/side/onetime/service/AdminService.java
+++ b/src/main/java/side/onetime/service/AdminService.java
@@ -245,7 +245,7 @@ public class AdminService {
 
         List<DashboardUser> dashboardUsers = users.stream()
                 .map(user -> {
-                    int participantCount = eventParticipationRepository.findAllByUser(user).size();
+                    int participantCount = eventParticipationRepository.findAllByUserWithEvent(user).size();
                     return DashboardUser.from(user, participantCount);
                 }).toList();
 

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -212,10 +212,8 @@ public class EventService {
      */
     @Transactional(readOnly = true)
     public GetParticipantsResponse getParticipants(String eventId) {
-        Event event = eventRepository.findByEventId(UUID.fromString(eventId))
+        Event event = eventRepository.findByEventIdWithMembers(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
-
-        List<Member> members = event.getMembers();
 
         // 이벤트 참여 상태가 CREATOR가 아닌 유저만 필터링하여 가져오기
         List<User> users = eventParticipationRepository.findAllByEvent(event).stream()
@@ -223,7 +221,7 @@ public class EventService {
                 .map(EventParticipation::getUser)
                 .toList();
 
-        return GetParticipantsResponse.of(members, users);
+        return GetParticipantsResponse.of(event.getMembers(), users);
     }
 
     /**

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -435,7 +435,7 @@ public class EventService {
         User user = userRepository.findById(UserAuthorizationUtil.getLoginUserId())
                 .orElseThrow(() -> new CustomException(UserErrorStatus._NOT_FOUND_USER));
 
-        List<EventParticipation> participations = eventParticipationRepository.findAllByUser(user);
+        List<EventParticipation> participations = eventParticipationRepository.findAllByUserWithEvent(user);
 
         // 캐시 맵 선언
         Map<String, GetParticipantsResponse> participantsCache = new HashMap<>();

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -486,26 +486,13 @@ public class EventService {
         EventParticipation eventParticipation = verifyUserHasEventAccess(user, eventId);
         Event event = eventParticipation.getEvent();
 
-        updateEventTitle(event, modifyUserCreatedEventRequest.title());
+        event.updateTitle(modifyUserCreatedEventRequest.title());
         updateEventRanges(event, event.getSchedules(), modifyUserCreatedEventRequest.ranges(), modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
 
         // 변경된 범위에 따른 새로운 스케줄 목록
         List<Schedule> newSchedules = scheduleRepository.findAllByEvent(event)
                 .orElseThrow(() -> new CustomException(ScheduleErrorStatus._NOT_FOUND_ALL_SCHEDULES));
         updateEventTimes(event, newSchedules, modifyUserCreatedEventRequest.startTime(), modifyUserCreatedEventRequest.endTime());
-    }
-
-    /**
-     * 이벤트 제목 업데이트 메서드.
-     * 이벤트의 제목을 새로운 제목으로 업데이트합니다.
-     *
-     * @param event 이벤트 객체
-     * @param newTitle 새로운 제목
-     */
-    private void updateEventTitle(Event event, String newTitle) {
-        if (newTitle != null) {
-            event.updateTitle(newTitle);
-        }
     }
 
     /**

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import side.onetime.domain.*;
 import side.onetime.domain.enums.EventStatus;
-import side.onetime.dto.event.response.GetParticipantsResponse;
 import side.onetime.dto.schedule.request.CreateDateScheduleRequest;
 import side.onetime.dto.schedule.request.CreateDayScheduleRequest;
 import side.onetime.dto.schedule.request.GetFilteredSchedulesRequest;
@@ -23,6 +22,7 @@ import side.onetime.util.JwtUtil;
 import side.onetime.util.UserAuthorizationUtil;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
@@ -225,7 +225,7 @@ public class ScheduleService {
      *
      * 이벤트에 참여하는 모든 사용자(멤버와 유저)의 요일 스케줄을 반환합니다.
      *
-     * @param eventId 조회할 이벤트 ID
+     * @param eventId 조회할 이벤트 ID (UUID 문자열)
      * @return 요일별 스케줄 응답 리스트
      */
     @Transactional(readOnly = true)
@@ -233,54 +233,52 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-        // 이벤트에 참여하는 모든 멤버
         List<Member> members = memberRepository.findAllByEvent(event);
 
-        // 이벤트에 참여하는 모든 참여자 목록
-        GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
-        List<String> participantNames = getParticipantsResponse.names();
-
-        // 이벤트에 참여하는 모든 유저 (CREATOR가 아닌 경우만 포함)
-        List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEvent(event);
-        List<User> users = eventParticipations.stream()
-                .filter(eventParticipation -> eventParticipation.getEventStatus() != EventStatus.CREATOR)
+        List<User> users = eventParticipationRepository.findAllByEvent(event).stream()
+                .filter(p -> p.getEventStatus() != EventStatus.CREATOR)
                 .map(EventParticipation::getUser)
                 .toList();
 
-        List<PerDaySchedulesResponse> perDaySchedulesResponses = new ArrayList<>();
+        List<PerDaySchedulesResponse> responses = new ArrayList<>();
 
-        // 멤버 스케줄 추가
         for (Member member : members) {
-            Map<String, List<Selection>> groupedSelectionsByDay = member.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDay(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DaySchedule> daySchedules = groupedSelectionsByDay.entrySet().stream()
-                    .map(entry -> DaySchedule.from(entry.getValue()))
-                    .collect(Collectors.toList());
-            perDaySchedulesResponses.add(PerDaySchedulesResponse.of(member.getName(), daySchedules));
+            List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
+            responses.add(toPerDaySchedules(member.getName(), selections,
+                    s -> s.getSchedule() != null && s.getSchedule().getDay() != null));
         }
 
-        // 유저 스케줄 추가
         for (User user : users) {
-            Map<String, List<Selection>> groupedSelectionsByDay = user.getSelections().stream()
-                    .filter(selection -> selection.getSchedule().getEvent().equals(event))
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDay(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DaySchedule> daySchedules = groupedSelectionsByDay.entrySet().stream()
-                    .map(entry -> DaySchedule.from(entry.getValue()))
-                    .collect(Collectors.toList());
-            perDaySchedulesResponses.add(PerDaySchedulesResponse.of(user.getNickname(), daySchedules));
+            List<Selection> selections = selectionRepository.findAllByUserWithScheduleAndEvent(user);
+            responses.add(toPerDaySchedules(user.getNickname(), selections,
+                    s -> s.getSchedule().getDay() != null && s.getSchedule().getEvent().equals(event)));
         }
 
-        return perDaySchedulesResponses;
+        return responses;
+    }
+
+    /**
+     * 선택 스케줄 리스트를 요일별로 그룹화하여 PerDaySchedulesResponse로 변환합니다.
+     *
+     * @param name 응답에 포함될 이름 (닉네임 또는 멤버명)
+     * @param selections 선택 스케줄 목록
+     * @param filter 적용할 필터 조건
+     * @return PerDaySchedulesResponse 객체
+     */
+    private PerDaySchedulesResponse toPerDaySchedules(String name, List<Selection> selections, Predicate<Selection> filter) {
+        Map<String, List<Selection>> grouped = selections.stream()
+                .filter(filter)
+                .collect(Collectors.groupingBy(
+                        s -> s.getSchedule().getDay(),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        List<DaySchedule> daySchedules = grouped.values().stream()
+                .map(DaySchedule::from)
+                .collect(Collectors.toList());
+
+        return PerDaySchedulesResponse.of(name, daySchedules);
     }
 
     /**
@@ -348,9 +346,10 @@ public class ScheduleService {
     /**
      * 전체 날짜 스케줄 반환 메서드.
      *
-     * 이벤트에 참여하는 모든 사용자(멤버와 유저)의 날짜 스케줄을 반환합니다.
+     * 특정 이벤트에 참여한 멤버와 유저의 선택 스케줄을 조회하고,
+     * 날짜별로 그룹화하여 응답 형태로 반환합니다.
      *
-     * @param eventId 조회할 이벤트 ID
+     * @param eventId 조회할 이벤트 ID (UUID 문자열)
      * @return 날짜별 스케줄 응답 리스트
      */
     @Transactional(readOnly = true)
@@ -358,54 +357,55 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-        // 이벤트에 참여하는 모든 멤버
         List<Member> members = memberRepository.findAllByEvent(event);
 
-        // 이벤트에 참여하는 모든 참여자 목록
-        GetParticipantsResponse getParticipantsResponse = eventService.getParticipants(eventId);
-        List<String> participantNames = getParticipantsResponse.names();
-
-        // 이벤트에 참여하는 모든 유저 (CREATOR가 아닌 경우만 포함)
-        List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEvent(event);
-        List<User> users = eventParticipations.stream()
-                .filter(eventParticipation -> eventParticipation.getEventStatus() != EventStatus.CREATOR)
+        List<User> users = eventParticipationRepository.findAllByEvent(event).stream()
+                .filter(p -> p.getEventStatus() != EventStatus.CREATOR)
                 .map(EventParticipation::getUser)
                 .toList();
 
-        List<PerDateSchedulesResponse> perDateSchedulesResponses = new ArrayList<>();
+        List<PerDateSchedulesResponse> responses = new ArrayList<>();
 
-        // 멤버 스케줄 추가
         for (Member member : members) {
-            Map<String, List<Selection>> groupedSelectionsByDate = member.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDate(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DateSchedule> dateSchedules = groupedSelectionsByDate.entrySet().stream()
-                    .map(entry -> DateSchedule.from(entry.getValue()))
-                    .collect(Collectors.toList());
-            perDateSchedulesResponses.add(PerDateSchedulesResponse.of(member.getName(), dateSchedules));
+            List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
+            responses.add(toPerDateSchedules(member.getName(), selections,
+                    s -> s.getSchedule() != null && s.getSchedule().getDate() != null));
         }
 
-        // 유저 스케줄 추가
         for (User user : users) {
-            Map<String, List<Selection>> groupedSelectionsByDate = user.getSelections().stream()
-                    .filter(selection -> selection.getSchedule().getEvent().equals(event))
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDate(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DateSchedule> dateSchedules = groupedSelectionsByDate.entrySet().stream()
-                    .map(entry -> DateSchedule.from(entry.getValue()))
-                    .collect(Collectors.toList());
-            perDateSchedulesResponses.add(PerDateSchedulesResponse.of(user.getNickname(), dateSchedules));
+            List<Selection> selections = selectionRepository.findAllByUserWithScheduleAndEvent(user);
+            responses.add(toPerDateSchedules(user.getNickname(), selections,
+                    s -> s.getSchedule().getDate() != null && s.getSchedule().getEvent().equals(event)));
         }
 
-        return perDateSchedulesResponses;
+        return responses;
+    }
+
+    /**
+     * 선택 스케줄 리스트를 날짜별로 그룹화하여 PerDateSchedulesResponse로 변환합니다.
+     *
+     * 필터 조건에 따라 스케줄을 선별하고,
+     * 같은 날짜의 스케줄을 하나의 DateSchedule로 묶어 응답 객체로 구성합니다.
+     *
+     * @param name 응답에 포함될 이름 (닉네임 또는 멤버명)
+     * @param selections 선택 스케줄 목록
+     * @param filter 적용할 필터 조건
+     * @return PerDateSchedulesResponse 객체
+     */
+    private PerDateSchedulesResponse toPerDateSchedules(String name, List<Selection> selections, Predicate<Selection> filter) {
+        Map<String, List<Selection>> grouped = selections.stream()
+                .filter(filter)
+                .collect(Collectors.groupingBy(
+                        s -> s.getSchedule().getDate(),
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        List<DateSchedule> dateSchedules = grouped.values().stream()
+                .map(DateSchedule::from)
+                .collect(Collectors.toList());
+
+        return PerDateSchedulesResponse.of(name, dateSchedules);
     }
 
     /**

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -34,7 +34,6 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final SelectionRepository selectionRepository;
     private final JwtUtil jwtUtil;
-    private final EventService eventService;
     private final UserRepository userRepository;
 
     /**


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- 참여한 이벤트 조회 API의 성능을 개선하였습니다. (`3.67s -> 2.7s`)
- `getParticipants()` 호출 최적화 (이미 조회한 데이터 재활용)
- `getMostPossibleTime()` 로직 정리 및 불필요한 호출 제거
- `buildScheduleToNamesMap()` 연산 비용 절감

### 개선 이전

<img width="962" alt="스크린샷 2025-05-22 오후 1 59 51" src="https://github.com/user-attachments/assets/1c865ab7-9a90-46d8-b168-34a8bdf02762" />

- 평균 응답 속도 `3.67s`

### 개선 이후

<img width="990" alt="image" src="https://github.com/user-attachments/assets/43b1993f-2140-40de-97c7-1b48e434063f" />

- 평균 응답 속도 `2.7s`
- 요청 당 약 1초 가량 개선 완료

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Ref : #233 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
