### PR TITLE
[feat] : 토큰 내 클레임에 브라우저 id를 추가하여 관리한다

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,5 +14,5 @@ permissions:
 hooks:
   ApplicationStart:
     - location: deploy/deploy.sh
-      timeout: 60
+      timeout: 180
       runas: ubuntu

--- a/src/main/java/side/onetime/auth/handler/OAuthLoginSuccessHandler.java
+++ b/src/main/java/side/onetime/auth/handler/OAuthLoginSuccessHandler.java
@@ -121,7 +121,8 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
      * @throws IOException 인증 처리 중 발생할 수 있는 입출력 예외
      */
     private void handleNewUser(HttpServletRequest request, HttpServletResponse response, String provider, String providerId, String name, String email) throws IOException {
-        String registerToken = jwtUtil.generateRegisterToken(provider, providerId, name, email);
+        String browserId = jwtUtil.hashUserAgent(request.getHeader("User-Agent"));
+        String registerToken = jwtUtil.generateRegisterToken(provider, providerId, name, email, browserId);
         String redirectUri = String.format(REGISTER_TOKEN_REDIRECT_URI, registerToken, URLEncoder.encode(name, StandardCharsets.UTF_8));
         getRedirectStrategy().sendRedirect(request, response, redirectUri);
     }
@@ -129,8 +130,8 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     /**
      * 기존 유저 처리 메서드.
      *
-     * OAuth2 인증을 통해 로그인한 기존 사용자를 처리하고,
-     * 액세스 및 리프레쉬 토큰을 발급하여 리다이렉트를 수행합니다.
+     * OAuth2 인증을 통해 로그인한 기존 사용자를 처리하고, 브라우저 식별값(User-Agent 기반 해시)을 이용해
+     * 액세스 및 리프레시 토큰을 생성하고 저장한 뒤, 클라이언트로 리다이렉트합니다.
      *
      * @param request  HttpServletRequest 객체
      * @param response HttpServletResponse 객체
@@ -142,7 +143,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
         String browserId = jwtUtil.hashUserAgent(request.getHeader("User-Agent"));
 
         String accessToken = jwtUtil.generateAccessToken(userId,"USER");
-        String refreshToken = jwtUtil.generateRefreshToken(userId);
+        String refreshToken = jwtUtil.generateRefreshToken(userId, browserId);
         refreshTokenRepository.save(new RefreshToken(userId, browserId, refreshToken));
 
         String redirectUri = String.format(ACCESS_TOKEN_REDIRECT_URI, "true", accessToken, refreshToken);

--- a/src/main/java/side/onetime/controller/TokenController.java
+++ b/src/main/java/side/onetime/controller/TokenController.java
@@ -1,16 +1,17 @@
 package side.onetime.controller;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import side.onetime.dto.token.request.ReissueTokenRequest;
 import side.onetime.dto.token.response.ReissueTokenResponse;
 import side.onetime.global.common.ApiResponse;
 import side.onetime.global.common.status.SuccessStatus;
 import side.onetime.service.TokenService;
-import side.onetime.util.JwtUtil;
 
 @RestController
 @RequestMapping("/api/v1/tokens")
@@ -18,24 +19,21 @@ import side.onetime.util.JwtUtil;
 public class TokenController {
 
     private final TokenService tokenService;
-    private final JwtUtil jwtUtil;
 
     /**
      * 액세스 토큰 재발행 API.
      *
-     * 클라이언트가 제공한 유효한 리프레쉬 토큰과 User-Agent를 기반으로
-     * 브라우저를 식별하고, 해당 브라우저에 대한 토큰이 존재할 경우
-     * 새로운 액세스 토큰과 리프레쉬 토큰을 발급하여 반환합니다.
+     * 이 API는 유효한 리프레쉬 토큰을 제공받아 새 액세스 토큰과 리프레쉬 토큰을 재발행합니다.
+     * 리프레쉬 토큰의 유효성을 검증하고, 인증 정보에 따라 토큰을 갱신합니다.
      *
-     * @param reissueAccessTokenRequest 클라이언트의 리프레쉬 토큰 요청 객체
-     * @return 새로운 액세스 토큰과 리프레쉬 토큰을 포함한 응답 객체
+     * @param reissueAccessTokenRequest 리프레쉬 토큰을 포함한 요청 객체
+     * @return 재발행된 액세스 토큰과 리프레쉬 토큰을 포함하는 응답 객체
      */
     @PostMapping("/action-reissue")
     public ResponseEntity<ApiResponse<ReissueTokenResponse>> reissueToken(
-            @Valid @RequestBody ReissueTokenRequest reissueAccessTokenRequest,
-            @Parameter(hidden = true) @RequestHeader("User-Agent") String userAgent) {
+            @Valid @RequestBody ReissueTokenRequest reissueAccessTokenRequest) {
 
-        ReissueTokenResponse reissueTokenResponse = tokenService.reissueToken(reissueAccessTokenRequest, jwtUtil.hashUserAgent(userAgent));
+        ReissueTokenResponse reissueTokenResponse = tokenService.reissueToken(reissueAccessTokenRequest);
         return ApiResponse.onSuccess(SuccessStatus._REISSUE_TOKENS, reissueTokenResponse);
     }
 }

--- a/src/main/java/side/onetime/controller/UserController.java
+++ b/src/main/java/side/onetime/controller/UserController.java
@@ -1,6 +1,5 @@
 package side.onetime.controller;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +15,6 @@ import side.onetime.dto.user.response.OnboardUserResponse;
 import side.onetime.global.common.ApiResponse;
 import side.onetime.global.common.status.SuccessStatus;
 import side.onetime.service.UserService;
-import side.onetime.util.JwtUtil;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -24,7 +22,6 @@ import side.onetime.util.JwtUtil;
 public class UserController {
 
     private final UserService userService;
-    private final JwtUtil jwtUtil;
 
     /**
      * 유저 온보딩 API.
@@ -36,10 +33,9 @@ public class UserController {
      */
     @PostMapping("/onboarding")
     public ResponseEntity<ApiResponse<OnboardUserResponse>> onboardUser(
-            @Valid @RequestBody OnboardUserRequest onboardUserRequest,
-            @Parameter(hidden = true) @RequestHeader("User-Agent") String userAgent) {
+            @Valid @RequestBody OnboardUserRequest onboardUserRequest) {
 
-        OnboardUserResponse onboardUserResponse = userService.onboardUser(onboardUserRequest, jwtUtil.hashUserAgent(userAgent));
+        OnboardUserResponse onboardUserResponse = userService.onboardUser(onboardUserRequest);
         return ApiResponse.onSuccess(SuccessStatus._ONBOARD_USER, onboardUserResponse);
     }
 

--- a/src/main/java/side/onetime/service/TokenService.java
+++ b/src/main/java/side/onetime/service/TokenService.java
@@ -27,14 +27,14 @@ public class TokenService {
      * 기존 토큰은 삭제되고 최신 토큰으로 갱신됩니다.
      *
      * @param reissueTokenRequest 클라이언트가 보낸 리프레시 토큰 요청 객체
-     * @param browserId 브라우저 식별을 위한 해시된 ID
      * @return 새롭게 발급된 액세스 토큰 및 리프레시 토큰 응답 객체
      * @throws CustomException 유효하지 않은 리프레시 토큰일 경우 예외 발생
      */
-    public ReissueTokenResponse reissueToken(ReissueTokenRequest reissueTokenRequest, String browserId) {
+    public ReissueTokenResponse reissueToken(ReissueTokenRequest reissueTokenRequest) {
         String refreshToken = reissueTokenRequest.refreshToken();
 
         Long userId = jwtUtil.getClaimFromToken(refreshToken, "userId", Long.class);
+        String browserId = jwtUtil.getClaimFromToken(refreshToken, "browserId", String.class);
         String existRefreshToken = refreshTokenRepository.findByUserIdAndBrowserId(userId, browserId)
                 .orElseThrow(() -> new CustomException(TokenErrorStatus._NOT_FOUND_REFRESH_TOKEN));
 
@@ -43,7 +43,7 @@ public class TokenService {
         }
 
         String newAccessToken = jwtUtil.generateAccessToken(userId, "USER");
-        String newRefreshToken = jwtUtil.generateRefreshToken(userId);
+        String newRefreshToken = jwtUtil.generateRefreshToken(userId, browserId);
         refreshTokenRepository.save(new RefreshToken(userId, browserId, newRefreshToken));
 
         return ReissueTokenResponse.of(newAccessToken, newRefreshToken);

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -94,6 +94,7 @@ jwt:
     expiration-time: ${REFRESH_TOKEN_EXPIRATION_TIME}
   register-token:
     expiration-time: ${REGISTER_TOKEN_EXPIRATION_TIME}
+  browser-id-salt: ${BROWSER_ID_SALT}
 
 scheduling:
   cron: ${CRON}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -65,6 +65,7 @@ jwt:
     expiration-time: ${REFRESH_TOKEN_EXPIRATION_TIME}
   register-token:
     expiration-time: ${REGISTER_TOKEN_EXPIRATION_TIME}
+  browser-id-salt: ${BROWSER_ID_SALT}
 
 scheduling:
   cron: ${CRON}

--- a/src/test/java/side/onetime/token/TokenControllerTest.java
+++ b/src/test/java/side/onetime/token/TokenControllerTest.java
@@ -22,7 +22,6 @@ import side.onetime.util.JwtUtil;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -48,8 +47,8 @@ public class TokenControllerTest extends ControllerTestConfig {
         String newRefreshToken = "newRefreshToken";
         ReissueTokenResponse response = ReissueTokenResponse.of(newAccessToken, newRefreshToken);
 
-        Mockito.when(tokenService.reissueToken(any(ReissueTokenRequest.class), anyString())).thenReturn(response);
-        Mockito.when(jwtUtil.hashUserAgent(anyString())).thenReturn("mockBrowserId");
+        Mockito.when(tokenService.reissueToken(any(ReissueTokenRequest.class)))
+                .thenReturn(response);
 
         ReissueTokenRequest request = new ReissueTokenRequest(oldRefreshToken);
         String requestContent = new ObjectMapper().writeValueAsString(request);
@@ -57,7 +56,6 @@ public class TokenControllerTest extends ControllerTestConfig {
         // when
         ResultActions resultActions = mockMvc.perform(
                 RestDocumentationRequestBuilders.post("/api/v1/tokens/action-reissue")
-                        .header("User-Agent", "Test-Browser")
                         .content(requestContent)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/side/onetime/user/UserControllerTest.java
+++ b/src/test/java/side/onetime/user/UserControllerTest.java
@@ -29,7 +29,6 @@ import side.onetime.util.JwtUtil;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -52,8 +51,7 @@ public class UserControllerTest extends ControllerTestConfig {
     public void onboardUser() throws Exception {
         // given
         OnboardUserResponse response = new OnboardUserResponse("sampleAccessToken", "sampleRefreshToken");
-        Mockito.when(userService.onboardUser(any(OnboardUserRequest.class), anyString())).thenReturn(response);
-        Mockito.when(jwtUtil.hashUserAgent(anyString())).thenReturn("mockBrowserId");
+        Mockito.when(userService.onboardUser(any(OnboardUserRequest.class))).thenReturn(response);
 
         OnboardUserRequest request = new OnboardUserRequest(
                 "sampleRegisterToken",
@@ -69,7 +67,6 @@ public class UserControllerTest extends ControllerTestConfig {
 
         // when
         ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/users/onboarding")
-                .header("User-Agent", "Mozilla/5.0 (Test-Agent)")
                 .content(requestContent)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON));
@@ -170,7 +167,7 @@ public class UserControllerTest extends ControllerTestConfig {
         UpdateUserProfileRequest request = new UpdateUserProfileRequest(
                 "NewNickname",
                 Language.ENG
-                );
+        );
         Mockito.doNothing().when(userService).updateUserProfile(any(UpdateUserProfileRequest.class));
         String requestContent = objectMapper.writeValueAsString(request);
 


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제점

- 기존에는 클라이언트 → 서버 요청 간 브라우저 ID(User-Agent 기반 해시값)가 일치하지 않아, 이를 레디스에서 찾지 못 했습니다.

### ✅ 해결

- 클라이언트 측에서 추가로 보내주는 방법도 고려하였으나, 소셜 로그인 시에는 이를 받기가 어렵고, 클라이언트 측 구현 부담도 존재하기에 토큰 내 클레임에 담는 것으로 결정하였습니다.
- 해당 클레임을 추출하여 유저 & 브라우저를 구분합니다.
- 동일한 User-Agent에 대한 해시 충돌 방지 및 예측 가능성 최소화를 위해, 해싱 시 `salt 값`을 추가하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #242 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 브라우저 식별자를 User-Agent 해시와 별도 salt 값을 활용해 생성하고, 이를 토큰 발급 및 저장 과정에 반영하도록 개선되었습니다.

- **버그 수정**
  - 토큰 재발급 및 사용자 온보딩 요청에서 User-Agent 헤더 전달이 제거되어 간소화되었습니다.

- **문서화**
  - API 문서 및 주석이 변경된 동작 방식에 맞게 업데이트되었습니다.

- **테스트**
  - User-Agent 관련 테스트 코드가 간소화되고, 불필요한 모킹과 헤더 사용이 제거되었습니다.

- **환경설정**
  - 브라우저 식별자 생성에 사용되는 salt 환경 변수 설정이 추가되었습니다.

- **기타**
  - 배포 설정에서 ApplicationStart 타임아웃이 60초에서 180초로 연장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->