### PR TITLE
[fix] : Redisson + AOP 분산 락 기능을 구현하여 동시성 문제를 해결한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.28.0'
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/side/onetime/controller/TokenController.java
+++ b/src/main/java/side/onetime/controller/TokenController.java
@@ -23,9 +23,6 @@ public class TokenController {
     /**
      * 액세스 토큰 재발행 API.
      *
-     * 이 API는 유효한 리프레쉬 토큰을 제공받아 새 액세스 토큰과 리프레쉬 토큰을 재발행합니다.
-     * 리프레쉬 토큰의 유효성을 검증하고, 인증 정보에 따라 토큰을 갱신합니다.
-     *
      * @param reissueAccessTokenRequest 리프레쉬 토큰을 포함한 요청 객체
      * @return 재발행된 액세스 토큰과 리프레쉬 토큰을 포함하는 응답 객체
      */

--- a/src/main/java/side/onetime/dto/token/request/ReissueTokenRequest.java
+++ b/src/main/java/side/onetime/dto/token/request/ReissueTokenRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReissueTokenRequest(
-        @NotBlank(message = "리프레쉬 토큰은 필수 값입니다.") String refreshToken
+        @NotBlank(message = "리프레쉬 토큰은 필수 값입니다.")
+        String refreshToken
 ) {
 }

--- a/src/main/java/side/onetime/exception/status/TokenErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/TokenErrorStatus.java
@@ -17,6 +17,7 @@ public enum TokenErrorStatus implements BaseErrorCode {
     _TOKEN_CLAIM_EXTRACTION_ERROR(HttpStatus.UNAUTHORIZED, "TOKEN-006", "토큰에서 claim 값을 추출하던 도중 에러가 발생했습니다."),
     _INVALID_USER_TYPE(HttpStatus.BAD_REQUEST, "TOKEN-007", "알 수 없는 타입의 액세스 토큰이 발행되었습니다."),
     _NOT_FOUND_HEADER(HttpStatus.BAD_REQUEST, "TOKEN-008", "Authorization 헤더가 존재하지 않거나 형식이 잘못되었습니다."),
+    _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "TOKEN-009", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/global/config/RedissonConfig.java
+++ b/src/main/java/side/onetime/global/config/RedissonConfig.java
@@ -1,0 +1,26 @@
+package side.onetime.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+              .setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/side/onetime/global/lock/annotation/DistributedLock.java
+++ b/src/main/java/side/onetime/global/lock/annotation/DistributedLock.java
@@ -1,0 +1,17 @@
+package side.onetime.global.lock.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String prefix();
+    String key();
+    long waitTime() default 2L;
+    long leaseTime() default 3L;
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/side/onetime/global/lock/aop/DistributedLockAop.java
+++ b/src/main/java/side/onetime/global/lock/aop/DistributedLockAop.java
@@ -1,0 +1,50 @@
+package side.onetime.global.lock.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import side.onetime.exception.CustomException;
+import side.onetime.exception.status.TokenErrorStatus;
+import side.onetime.global.lock.annotation.DistributedLock;
+import side.onetime.global.lock.util.CustomSpringELParser;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAop {
+
+    private final RedissonClient redissonClient;
+    private final CustomSpringELParser parser = new CustomSpringELParser();
+
+    @Around("@annotation(lock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock lock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String dynamicKey = parser.getDynamicValue(signature.getMethod(), joinPoint.getArgs(), lock.key());
+        String lockName = lock.prefix() + ":" + dynamicKey;
+
+        RLock rLock = redissonClient.getLock(lockName);
+        boolean available = false;
+
+        try {
+            available = rLock.tryLock(lock.waitTime(), lock.leaseTime(), lock.timeUnit());
+            if (!available) {
+                throw new CustomException(TokenErrorStatus._TOO_MANY_REQUESTS);
+            }
+
+            log.debug("🔐 락 획득: {}", lockName);
+            return joinPoint.proceed();
+        } finally {
+            if (available && rLock.isHeldByCurrentThread()) {
+                rLock.unlock();
+                log.debug("🔓 락 해제: {}", lockName);
+            }
+        }
+    }
+}

--- a/src/main/java/side/onetime/global/lock/util/CustomSpringELParser.java
+++ b/src/main/java/side/onetime/global/lock/util/CustomSpringELParser.java
@@ -1,0 +1,29 @@
+package side.onetime.global.lock.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.lang.reflect.Method;
+
+@RequiredArgsConstructor
+public class CustomSpringELParser {
+
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+    private final DefaultParameterNameDiscoverer nameDiscoverer = new DefaultParameterNameDiscoverer();
+
+    public String getDynamicValue(Method method, Object[] args, String expression) {
+        EvaluationContext context = new StandardEvaluationContext();
+        String[] paramNames = nameDiscoverer.getParameterNames(method);
+
+        if (paramNames != null) {
+            for (int i = 0; i < paramNames.length; i++) {
+                context.setVariable(paramNames[i], args[i]);
+            }
+        }
+
+        return parser.parseExpression(expression).getValue(context, String.class);
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제

- 현재는 토큰 재발행 시, 리프레쉬 토큰까지 함께 재발행 되는 구조입니다.
- 1명의 유저가 동시에 재발행 요청을 하는 경우, 후에 들어온 요청에 있는 리프레쉬 토큰은 유효하지 않게 되어 401 에러가 발생하였습니다.
- 때문에 재발행이 제대로 되지 않고, 재로그인을 해야 하는 문제가 있었습니다.

### ✅ 해결

- 분산 락 기능 구현을 위해 `Redisson` 의존성을 추가하였습니다.
- 분산 락 커스텀 어노테이션 및 AOP 기능을 구현하였습니다.
- 이를 토큰 재발행 비즈니스 로직에 추가함으로써 동시성 문제를 해결하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #247 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
