### PR TITLE
[fix] : 참여 이벤트 존재 시, 유저 탈퇴가 되지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/repository/custom/UserRepositoryImpl.java
+++ b/src/main/java/side/onetime/repository/custom/UserRepositoryImpl.java
@@ -28,50 +28,57 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
      * 인증된 유저의 계정을 삭제하고,
      * 유저가 생성한(즉, EventParticipation의 상태가 PARTICIPANT가 아닌) 이벤트를 함께 삭제합니다.
      *
-     * 삭제 순서: Selection → EventParticipation → Schedule → Member → Event
+     * 삭제 순서:
+     * 1. 유저가 생성한 이벤트의 Selection → EventParticipation → Schedule → Member → Event
+     * 2. 유저가 직접 소유한 Selection → FixedSelection
+     * 3. 최종적으로 User
      *
      * @param user 탈퇴할 유저
      */
     @Override
     public void withdraw(User user) {
-        // 유저가 생성한 이벤트(참여 상태가 PARTICIPANT가 아닌)를 조회
-        List<EventParticipation> participations = queryFactory
-                .selectFrom(QEventParticipation.eventParticipation)
+        // 유저가 생성한 이벤트 ID 리스트 조회
+        List<Long> eventIds = queryFactory
+                .select(QEventParticipation.eventParticipation.event.id)
+                .from(QEventParticipation.eventParticipation)
                 .where(
                         QEventParticipation.eventParticipation.user.eq(user)
                                 .and(QEventParticipation.eventParticipation.eventStatus.ne(EventStatus.PARTICIPANT))
                 )
                 .fetch();
 
-        // 삭제 쿼리 수행.
-        for (EventParticipation participation : participations) {
-            Event event = participation.getEvent();
-
+        if (!eventIds.isEmpty()) {
             queryFactory.delete(QSelection.selection)
-                    .where(QSelection.selection.schedule.event.eq(event))
+                    .where(QSelection.selection.schedule.event.id.in(eventIds))
                     .execute();
 
             queryFactory.delete(QEventParticipation.eventParticipation)
-                    .where(QEventParticipation.eventParticipation.event.eq(event))
+                    .where(QEventParticipation.eventParticipation.event.id.in(eventIds))
                     .execute();
 
             queryFactory.delete(QSchedule.schedule)
-                    .where(QSchedule.schedule.event.eq(event))
+                    .where(QSchedule.schedule.event.id.in(eventIds))
                     .execute();
 
             queryFactory.delete(QMember.member)
-                    .where(QMember.member.event.eq(event))
+                    .where(QMember.member.event.id.in(eventIds))
                     .execute();
 
             queryFactory.delete(QEvent.event)
-                    .where(QEvent.event.eq(event))
+                    .where(QEvent.event.id.in(eventIds))
                     .execute();
         }
+
+        // 유저 소유 Selection 및 FixedSelection 삭제
+        queryFactory.delete(QSelection.selection)
+                .where(QSelection.selection.user.eq(user))
+                .execute();
 
         queryFactory.delete(QFixedSelection.fixedSelection)
                 .where(QFixedSelection.fixedSelection.user.eq(user))
                 .execute();
 
+        // 최종적으로 유저 삭제
         queryFactory.delete(QUser.user)
                 .where(QUser.user.eq(user))
                 .execute();

--- a/src/main/java/side/onetime/repository/custom/UserRepositoryImpl.java
+++ b/src/main/java/side/onetime/repository/custom/UserRepositoryImpl.java
@@ -69,13 +69,17 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                     .execute();
         }
 
-        // 유저 소유 Selection 및 FixedSelection 삭제
+        // 유저 소유 Selection, FixedSelection, eventParticipation 삭제
         queryFactory.delete(QSelection.selection)
                 .where(QSelection.selection.user.eq(user))
                 .execute();
 
         queryFactory.delete(QFixedSelection.fixedSelection)
                 .where(QFixedSelection.fixedSelection.user.eq(user))
+                .execute();
+
+        queryFactory.delete(QEventParticipation.eventParticipation)
+                .where(QEventParticipation.eventParticipation.user.eq(user))
                 .execute();
 
         // 최종적으로 유저 삭제


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 기존 문제점
- 유저가 생성한 이벤트에 대해서만 제거되었기에, 참여한 이벤트와 관련한 데이터들은 고아 객체로 남는 문제가 있었습니다. 때문에 탈퇴가 정상적으로 처리되지 않았습니다.
- 또한 유저 탈퇴 쿼리에서 아래와 같은 성능적 문제도 존재했습니다.

1. 루프 기반 삭제: 이벤트마다 Selection, EventParticipation, Schedule, Member, Event 삭제 쿼리를 반복 실행 → 이벤트 개수가 많을수록 쿼리 수 급증
2. 코드 유지보수성 낮음: 중복된 delete 코드가 루프 내에 반복됨 → 코드 길어지고 관리 어려움

### ✅ 변경 후 개선점
- 유저 탈퇴 처리가 되지 않는 문제를 해결하였습니다.
- `배치 delete를 적용` : 이벤트 ID 목록을 한 번에 모아서 IN 조건으로 삭제 → 쿼리 5회로 모든 이벤트 관련 데이터를 삭제합니다.
- `코드 간결화` : 루프 제거, 중복 코드 제거 → 가독성 높고 유지보수가 용이해졌습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #249 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
