### PR TITLE
[fix] : 필터링 참여자 대상 최적 시간 조회 시, 모두 되는 시간이 없어 빈 리스트를 반환하여 발생하는 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -459,25 +459,6 @@ public class EventService {
     }
 
     /**
-     * 전체 참여자가 모두 가능한 스케줄만 필터링하는 메서드.
-     * 입력으로 주어진 스케줄-참여자 매핑에서, 모든 참여자가 포함된 스케줄만 남겨 반환합니다.
-     *
-     * @param scheduleToNamesMap 스케줄과 참여자 이름 매핑 데이터
-     * @param allParticipants 전체 참여자 이름 목록
-     * @return 전체 참여자가 모두 가능한 스케줄과 참여자 이름 매핑 데이터
-     */
-    private Map<Schedule, List<String>> filterSchedulesWithAllParticipants(Map<Schedule, List<String>> scheduleToNamesMap, List<String> allParticipants) {
-        return scheduleToNamesMap.entrySet().stream()
-                .filter(entry -> new HashSet<>(entry.getValue()).containsAll(allParticipants))
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        Map.Entry::getValue,
-                        (a, b) -> a,
-                        LinkedHashMap::new // buildScheduleToNamesMap()에서 정렬된 순서 유지
-                ));
-    }
-
-    /**
      * 날짜 포맷 여부 검증 메서드.
      * 주어진 문자열이 날짜 형식인지 확인합니다.
      *

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -314,12 +314,9 @@ public class EventService {
         // 6. 스케줄 기준으로 참여자 이름 매핑 생성
         Map<Schedule, List<String>> scheduleToNamesMap = buildScheduleToNamesMap(allSelections, event.getCategory());
 
-        // 7. 전체 참여자가 모두 가능한 시간대만 필터링
-        Map<Schedule, List<String>> filteredScheduleToNamesMap = filterSchedulesWithAllParticipants(scheduleToNamesMap, allParticipants);
-
-        // 8. 필터링된 시간대로부터 최적 시간대 리스트 구성
+        // 7. 최적 시간대 리스트 구성
         List<GetMostPossibleTime> mostPossibleTimes = buildMostPossibleTimes(
-                filteredScheduleToNamesMap, allParticipants, event.getCategory());
+                scheduleToNamesMap, allParticipants, event.getCategory());
 
         return DateUtil.sortMostPossibleTimes(mostPossibleTimes, event.getCategory());
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -99,6 +99,7 @@ jwt:
     expiration-time: ${REFRESH_TOKEN_EXPIRATION_TIME}
   register-token:
     expiration-time: ${REGISTER_TOKEN_EXPIRATION_TIME}
+  browser-id-salt: ${BROWSER_ID_SALT}
 
 scheduling:
   cron: ${CRON}


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- 필터링 참여자 대상 최적 시간 조회 시, 모두 되는 시간이 없어 빈 리스트를 반환하여 문제가 발생했습니다.
- 기존 UI와의 통일성을 위해서 모두 되지 않더라도 순차적으로 10개를 반환하도록 수정하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #263 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 모든 참가자가 가능한 일정만 표시하던 제한이 제거되어, 더 다양한 가능한 일정이 표시됩니다.

* **환경설정**
  * `browser-id-salt` 환경 변수가 추가되어 JWT 설정이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->