### PR TITLE
[feat] : 개인 요일/날짜 스케줄 조회 시 N+1 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/repository/SelectionRepository.java
+++ b/src/main/java/side/onetime/repository/SelectionRepository.java
@@ -37,16 +37,16 @@ public interface SelectionRepository extends JpaRepository<Selection, Long> {
     @Query("""
         SELECT s FROM Selection s
         JOIN FETCH s.schedule sc
-        JOIN FETCH sc.event
-        WHERE s.user = :user
+        JOIN FETCH sc.event e
+        WHERE e = :event AND (s.user.id IN :userIds OR s.member.id IN :memberIds)
     """)
-    List<Selection> findAllByUserWithScheduleAndEvent(@Param("user") User user);
+    List<Selection> findAllByUserIdsOrMemberIdsWithScheduleAndEvent(@Param("event") Event event, @Param("userIds") List<Long> userIds, @Param("memberIds") List<Long> memberIds);
 
     @Query("""
         SELECT s FROM Selection s
         JOIN FETCH s.schedule sc
         JOIN FETCH sc.event e
-        WHERE e = :event AND (s.user.id IN :userIds OR s.member.id IN :memberIds)
+        WHERE s.user = :user AND e = :event
     """)
-    List<Selection> findAllByUserIdsOrMemberIdsWithScheduleAndEvent(@Param("event") Event event, @Param("userIds") List<Long> userIds, @Param("memberIds") List<Long> memberIds);
+    List<Selection> findAllByUserAndEventWithScheduleAndEvent(@Param("user") User user, @Param("event") Event event);
 }

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -441,35 +441,12 @@ public class ScheduleService {
         List<PerDaySchedulesResponse> perDaySchedulesResponses = new ArrayList<>();
 
         for (Member member : members) {
-            Map<String, List<Selection>> groupedSelectionsByDay = member.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDay(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DaySchedule> daySchedules = groupedSelectionsByDay.values().stream()
-                    .map(DaySchedule::from)
-                    .toList();
-
-            perDaySchedulesResponses.add(PerDaySchedulesResponse.of(member.getName(), daySchedules));
+            perDaySchedulesResponses.add(toPerDaySchedules(member.getName(), member.getSelections(), s -> s.getSchedule().getDay() != null));
         }
 
         for (User user : users) {
-            Map<String, List<Selection>> groupedSelectionsByDay = user.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDay(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DaySchedule> daySchedules = groupedSelectionsByDay.values().stream()
-                    .map(DaySchedule::from)
-                    .toList();
-
-            perDaySchedulesResponses.add(PerDaySchedulesResponse.of(user.getNickname(), daySchedules));
+            perDaySchedulesResponses.add(toPerDaySchedules(user.getNickname(),user.getSelections(), s -> s.getSchedule().getDay() != null));
         }
-
 
         return perDaySchedulesResponses;
     }
@@ -493,32 +470,11 @@ public class ScheduleService {
         List<PerDateSchedulesResponse> perDateSchedulesResponses = new ArrayList<>();
 
         for (Member member : members) {
-            Map<String, List<Selection>> groupedSelectionsByDate = member.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDate(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DateSchedule> dateSchedules = groupedSelectionsByDate.values().stream()
-                    .map(DateSchedule::from)
-                    .toList();
-            perDateSchedulesResponses.add(PerDateSchedulesResponse.of(member.getName(), dateSchedules));
+            perDateSchedulesResponses.add(toPerDateSchedules(member.getName(), member.getSelections(), s -> s.getSchedule().getDate() != null));
         }
 
         for (User user : users) {
-            Map<String, List<Selection>> groupedSelectionsByDate = user.getSelections().stream()
-                    .collect(Collectors.groupingBy(
-                            selection -> selection.getSchedule().getDate(),
-                            LinkedHashMap::new,
-                            Collectors.toList()
-                    ));
-
-            List<DateSchedule> dateSchedules = groupedSelectionsByDate.values().stream()
-                    .map(DateSchedule::from)
-                    .toList();
-
-            perDateSchedulesResponses.add(PerDateSchedulesResponse.of(user.getNickname(), dateSchedules));
+            perDateSchedulesResponses.add(toPerDateSchedules(user.getNickname(), user.getSelections(), s -> s.getSchedule().getDate() != null));
         }
 
         return perDateSchedulesResponses;

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -243,8 +243,7 @@ public class ScheduleService {
 
         for (Member member : members) {
             List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
-            responses.add(toPerDaySchedules(member.getName(), selections,
-                    s -> s.getSchedule() != null && s.getSchedule().getDay() != null));
+            responses.add(toPerDaySchedules(member.getName(), selections, s -> s.getSchedule().getDay() != null));
         }
 
         for (User user : users) {
@@ -296,18 +295,8 @@ public class ScheduleService {
         Member member = memberRepository.findByMemberId(UUID.fromString(memberId))
                 .orElseThrow(() -> new CustomException(MemberErrorStatus._NOT_FOUND_MEMBER));
 
-        Map<String, List<Selection>> groupedSelectionsByDay = member.getSelections().stream()
-                .collect(Collectors.groupingBy(
-                        selection -> selection.getSchedule().getDay(),
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-
-        List<DaySchedule> daySchedules = groupedSelectionsByDay.entrySet().stream()
-                .map(entry -> DaySchedule.from(entry.getValue()))
-                .collect(Collectors.toList());
-
-        return PerDaySchedulesResponse.of(member.getName(), daySchedules);
+        List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
+        return toPerDaySchedules(member.getName(), selections, s -> s.getSchedule().getDay() != null);
     }
 
     /**
@@ -355,8 +344,7 @@ public class ScheduleService {
 
         for (Member member : members) {
             List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
-            responses.add(toPerDateSchedules(member.getName(), selections,
-                    s -> s.getSchedule() != null && s.getSchedule().getDate() != null));
+            responses.add(toPerDateSchedules(member.getName(), selections, s -> s.getSchedule().getDate() != null));
         }
 
         for (User user : users) {
@@ -411,18 +399,8 @@ public class ScheduleService {
         Member member = memberRepository.findByMemberId(UUID.fromString(memberId))
                 .orElseThrow(() -> new CustomException(MemberErrorStatus._NOT_FOUND_MEMBER));
 
-        Map<String, List<Selection>> groupedSelectionsByDate = member.getSelections().stream()
-                .collect(Collectors.groupingBy(
-                        selection -> selection.getSchedule().getDate(),
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-
-        List<DateSchedule> dateSchedules = groupedSelectionsByDate.entrySet().stream()
-                .map(entry -> DateSchedule.from(entry.getValue()))
-                .collect(Collectors.toList());
-
-        return PerDateSchedulesResponse.of(member.getName(), dateSchedules);
+        List<Selection> selections = selectionRepository.findAllByMemberWithSchedule(member);
+        return toPerDateSchedules(member.getName(), selections, s -> s.getSchedule().getDate() != null);
     }
 
     /**

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -445,7 +445,7 @@ public class ScheduleService {
         }
 
         for (User user : users) {
-            perDaySchedulesResponses.add(toPerDaySchedules(user.getNickname(),user.getSelections(), s -> s.getSchedule().getDay() != null));
+            perDaySchedulesResponses.add(toPerDaySchedules(user.getNickname(), user.getSelections(), s -> s.getSchedule().getDay() != null));
         }
 
         return perDaySchedulesResponses;

--- a/src/main/java/side/onetime/service/ScheduleService.java
+++ b/src/main/java/side/onetime/service/ScheduleService.java
@@ -248,9 +248,8 @@ public class ScheduleService {
         }
 
         for (User user : users) {
-            List<Selection> selections = selectionRepository.findAllByUserWithScheduleAndEvent(user);
-            responses.add(toPerDaySchedules(user.getNickname(), selections,
-                    s -> s.getSchedule().getDay() != null && s.getSchedule().getEvent().equals(event)));
+            List<Selection> selections = selectionRepository.findAllByUserAndEventWithScheduleAndEvent(user, event);
+            responses.add(toPerDaySchedules(user.getNickname(), selections, s -> s.getSchedule().getDay() != null));
         }
 
         return responses;
@@ -327,19 +326,8 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-        Map<String, List<Selection>> groupedSelectionsByDay = user.getSelections().stream()
-                .filter(selection -> selection.getSchedule().getEvent().equals(event))
-                .collect(Collectors.groupingBy(
-                        selection -> selection.getSchedule().getDay(),
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-
-        List<DaySchedule> daySchedules = groupedSelectionsByDay.entrySet().stream()
-                .map(entry -> DaySchedule.from(entry.getValue()))
-                .collect(Collectors.toList());
-
-        return PerDaySchedulesResponse.of(user.getNickname(), daySchedules);
+        List<Selection> selections = selectionRepository.findAllByUserAndEventWithScheduleAndEvent(user, event);
+        return toPerDaySchedules(user.getNickname(), selections, s -> s.getSchedule().getDay() != null);
     }
 
     /**
@@ -372,9 +360,8 @@ public class ScheduleService {
         }
 
         for (User user : users) {
-            List<Selection> selections = selectionRepository.findAllByUserWithScheduleAndEvent(user);
-            responses.add(toPerDateSchedules(user.getNickname(), selections,
-                    s -> s.getSchedule().getDate() != null && s.getSchedule().getEvent().equals(event)));
+            List<Selection> selections = selectionRepository.findAllByUserAndEventWithScheduleAndEvent(user, event);
+            responses.add(toPerDateSchedules(user.getNickname(), selections, s -> s.getSchedule().getDate() != null));
         }
 
         return responses;
@@ -453,20 +440,8 @@ public class ScheduleService {
         Event event = eventRepository.findByEventId(UUID.fromString(eventId))
                 .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
 
-
-        Map<String, List<Selection>> groupedSelectionsByDate = user.getSelections().stream()
-                .filter(selection -> selection.getSchedule().getEvent().equals(event))
-                .collect(Collectors.groupingBy(
-                        selection -> selection.getSchedule().getDate(),
-                        LinkedHashMap::new,
-                        Collectors.toList()
-                ));
-
-        List<DateSchedule> dateSchedules = groupedSelectionsByDate.entrySet().stream()
-                .map(entry -> DateSchedule.from(entry.getValue()))
-                .collect(Collectors.toList());
-
-        return PerDateSchedulesResponse.of(user.getNickname(), dateSchedules);
+        List<Selection> selections = selectionRepository.findAllByUserAndEventWithScheduleAndEvent(user, event);
+        return toPerDateSchedules(user.getNickname(), selections, s -> s.getSchedule().getDate() != null);
     }
 
     /**


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

## 변경 1. 애플리케이션 필터 로직 -> DB 위임
### AS-IS
- 애플리케이션 내부에서 schedule의 event와 현재 event 확인하는 filter 로직을 사용
- 개선점 : DB에서 User의 모든 Selection을 조회 후 애플리케이션 레벨에서 필터링하므로, 불필요한 레코드까지 가져와 메모리를 낭비할 수 있습니다.

### TO-BE
- 애플리케이션 내부에서 schedule의 event와 현재 event 확인하는 filter 로직을 제거하고, DB에서 특정 event를 비교해 필요한 Selection만 가져오도록 변경하였습니다.

---

## 변경 2. User, Member 엔티티에서 연관된 Selection, Schedule를 페치 조인
### AS-IS
- 개선점 : User, Member의 Schedule을 가져오는 과정에서 Selection 쿼리 조회 후, 연관된 Schedule 개수 만큼 추가로 쿼리를 호출하는 N+1 문제가 발생합니다.

### TO-BE
- User, Member에서 Selection 조회 시, `user.getSelection()`, `member.getSelection()`을 통해 조회하는 것이 아닌, 기존의 fetch join을 사용하여 단일 쿼리로 전부 가져오도록 변경하였습니다.

---

## 변경 3. `toPerDateSchedules()`, `toPerDaySchedules()` 메소드 사용
### AS-IS
- 개선점 : `toPerDateSchedules()`, `toPerDaySchedules()` 메소드의 내부 로직과 같은 코드가 다른 메소드에 혼재되어 있습니다.

### TO-BE
- 중복 로직을 위 메소드로 전부 통합하였습니다.

--- 

## 변경 4. Predicate에서 `s.getSchedule() != null` 제거
### AS-IS
- `toPerDateSchedules()`, `toPerDaySchedules()` 메소드 호출부에서 Predicate 인수에 `selection.getSchedule()` null 체크하는 코드가 있습니다.
- 개선점 : fetch join은 inner join으로 가져오기 때문에 null이라면 조회하지 않아 불필요한 검증 로직이 추가되었습니다.

### TO-BE
- `selection.getSchedule()` null 검증하는 코드 제거하였습니다.

---

## 결론

> 기존에는 `user.getSelections()` 이후 `selection.getSchedule().getDay()` 호출 시, 각 `Selection`마다 `Schedule`을 **Lazy 로딩**하며 **N+1 문제**가 발생했고, `Selection`의 수만큼 추가적인 쿼리가 실행;
> 
> `JOIN FETCH`를 적용하여 `Selection`과 `Schedule`을 한 번의 쿼리로 함께 조회하도록 개선
> 
> → API 응답 속도가 평균 **234ms → 136ms**로 **약 42% 개선**

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #266 
---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

[개선 과정을 작성한 노션](https://zest-cover-c96.notion.site/API-2446be226427802fb815f861f18bc117?source=copy_link)

- 코드 변경된 API는 로컬/테스트 서버에서 테스트 완료했습니다! 개선 내용은 노션 확인 부탁드립니다:)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신뢰성/성능
  - 이벤트 기준의 서버측 필터링 강화로 스케줄 조회 정확도 및 일관성 향상
  - 중복 연산 제거와 집계 로직 통합으로 일/날짜별 스케줄 조회 응답 속도 개선
  - 불필요한 서버/클라이언트측 조건 검사 제거로 처리 효율 향상

- 리팩터링
  - 일/날짜 스케줄 집계를 공용 헬퍼로 통합해 코드 단순화
  - 사용자·이벤트 기반 조회 경로 정리로 데이터 흐름 일원화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->