### PR TITLE
[fix] : @Modifying에서 clearAutomatically 속성을 제거한다

### DIFF
--- a/src/main/java/side/onetime/repository/SelectionRepository.java
+++ b/src/main/java/side/onetime/repository/SelectionRepository.java
@@ -4,17 +4,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import side.onetime.domain.*;
+import side.onetime.domain.Event;
+import side.onetime.domain.Member;
+import side.onetime.domain.Selection;
+import side.onetime.domain.User;
 
 import java.util.List;
 
 public interface SelectionRepository extends JpaRepository<Selection, Long> {
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("DELETE FROM Selection s WHERE s.member = :member")
     void deleteAllByMember(@Param("member") Member member);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("DELETE FROM Selection s WHERE s.user = :user AND s.schedule.event = :event")
     void deleteAllByUserAndEvent(@Param("user") User user, @Param("event") Event event);
 


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

- 벌크 연산에서 기존 selection 제거 전에 clearAutomatically 속성을 사용해 영속성 컨텍스트를 비우고 벌크 연산을 진행했습니다.
- event_status 변경 과정에서 더티체킹 및 쓰기 지연으로 반영되지 않은 쿼리가 위 이유로 영속성 컨텍스트에서 제거되었고, 이벤트 참여자의 스케줄이 보이지 않는 문제가 발생했습니다.
- clearAutomatically 속성을 제거하여 해결하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Fixes : #280 
- Resolves : #273 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.
