### PR TITLE
remove: 레디스 관련 의존성을 제거한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ OneTime is a Spring Boot-based backend API for a collaborative event scheduling 
 - **Language**: Java 17
 - **Framework**: Spring Boot 3.3.2
 - **Database**: MySQL 8.0 with Spring Data JPA, QueryDSL 5.0
-- **Cache**: Redis with Redisson 3.46.0 (distributed locking)
 - **Security**: Spring Security, OAuth2 (Google, Kakao, Naver), JWT (JJWT 0.12.2)
 - **Cloud**: AWS S3 (Spring Cloud AWS 3.1.1), CodeDeploy
 - **Documentation**: Spring REST Docs 3.0.0, SpringDoc OpenAPI 2.1.0
@@ -56,7 +55,6 @@ src/main/java/side/onetime/
 ├── global/
 │   ├── config/          # Spring configurations
 │   ├── filter/          # JwtFilter
-│   ├── lock/            # @DistributedLock annotation & AOP
 │   └── common/          # ApiResponse<T>, status codes, BaseEntity
 ├── exception/           # CustomException, GlobalExceptionHandler
 ├── infra/               # External integrations (Everytime client)
@@ -79,7 +77,6 @@ src/main/java/side/onetime/
 
 ### Patterns
 - **Soft Delete**: `@SQLDelete`, `@SQLRestriction` with `Status` enum (ACTIVE, DELETED)
-- **Distributed Locking**: `@DistributedLock` annotation for race condition prevention
 - **DTO Conversion**: `toEntity()` methods, static factory `of()` methods
 - **Error Handling**: Domain-specific error status enums (e.g., `EventErrorStatus`)
 - **Dependency Injection**: Constructor injection with `@RequiredArgsConstructor`

--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,6 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/side/onetime/repository/ScheduleRepository.java
+++ b/src/main/java/side/onetime/repository/ScheduleRepository.java
@@ -1,6 +1,6 @@
 package side.onetime.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import side.onetime.domain.Event;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,11 +30,6 @@ spring:
               - profile
             redirect-uri: ${OAUTH_GOOGLE_REDIRECT_URI}
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
   cloud:
     aws:
       credentials:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -12,10 +12,6 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     show-sql: true
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 jwt:
   secret: test-secret-key-for-testing-purpose-only-should-be-256-bits-long


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용

> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

  - 사용하지 않는 Redis 의존성 제거 (spring-boot-starter-data-redis)
  - application.yaml 및 테스트 설정에서 Redis 관련 설정 제거
  - ScheduleRepository에서 잘못 사용된 Lettuce @Param → Spring Data @Param으로 수정
  - CLAUDE.md 문서에서 Redis 및 Distributed Locking 관련 내용 제거

  ---

## 📝️ 관련 이슈

> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

  - Resolved: #320

  ---

## 💬 기타 사항 or 추가 코멘트

> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

  - Redis 의존성이 추가되어 있었지만 실제 사용하는 코드가 없어 제거했습니다.
  - ScheduleRepository에서 io.lettuce.core.dynamic.annotation.Param을 사용하고 있었는데, 이는 Redis 의존성에 포함된 Lettuce 클라이언트의 어노테이션입니다. IDE 자동 import로 인해 잘못 선택된 것으로 보여 org.springframework.data.repository.query.Param으로 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 분산 잠금 관련 문서 항목 제거

* **Chores**
  * Redis 의존성 및 설정 제거
  * 라이브러리 import 경로 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->