### PR TITLE
[fix] : 이벤트 참여자별 멤버 중복 문제를 해결한다

### DIFF
--- a/src/main/java/side/onetime/repository/EventParticipationRepository.java
+++ b/src/main/java/side/onetime/repository/EventParticipationRepository.java
@@ -24,11 +24,10 @@ public interface EventParticipationRepository extends JpaRepository<EventPartici
     @Query("""
         SELECT ep FROM EventParticipation ep
         JOIN FETCH ep.event e
-        LEFT JOIN FETCH e.members
         LEFT JOIN FETCH ep.user
         WHERE ep.event = :event
     """)
-    List<EventParticipation> findAllByEventWithEventAndMemberAndUser(@Param("event") Event event);
+    List<EventParticipation> findAllByEventWithEventAndUser(@Param("event") Event event);
 
     EventParticipation findByUserAndEvent(User user, Event event);
 

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -538,7 +538,7 @@ public class EventService {
         List<GetParticipatedEventResponse> userParticipatedEvents = participations.stream()
                 .map(ep -> {
                     Event event = ep.getEvent();
-                    List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEventWithEventAndMemberAndUser(event);
+                    List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEventWithEventAndUser(event);
 
                     GetParticipantsResponse participants = this.getParticipants(event, eventParticipations);
                     List<GetMostPossibleTime> mostPossibleTimes = this.getMostPossibleTimes(event, eventParticipations);


### PR DESCRIPTION
## ✅ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용

```java
@Transactional(readOnly = true)
    public GetParticipatedEventsResponse getParticipatedEventsByCursor(int size, LocalDateTime createdDate) {
        ...

        /*
         * 1. 내가 참여한 이벤트 목록 조회 (Event와 Fetch Join)
         * 영속성 컨텍스트에 Event 엔티티들이 1차 캐싱
         */
        List<EventParticipation> participations = eventParticipationRepository.findParticipationsByUserWithCursor(user, createdDate, size);

        List<GetParticipatedEventResponse> userParticipatedEvents = participations.stream()
                .map(ep -> {
                    Event event = ep.getEvent(); // 1차 캐시된 Event 객체 참조
                     
                    /*
                     * 2. 특정 이벤트의 모든 참여자 정보 조회 (Event + Member Fetch Join)
                     * 이 쿼리에서 'Event x Member'의 1:N 페치 조인이 발생하여 결과 행(Row)이 중복 저장(add)
                     */
                    List<EventParticipation> eventParticipations = eventParticipationRepository.findAllByEventWithEventAndMemberAndUser(event);
                     
                    // 3. Event에 중복된 Member 수 카운트
                    GetParticipantsResponse participants = this.getParticipants(event, eventParticipations);
                    List<GetMostPossibleTime> mostPossibleTimes = this.getMostPossibleTimes(event, eventParticipations);
                    ...
        return GetParticipatedEventsResponse.of(userParticipatedEvents, pageCursorInfo);
    }
```

Row 1: EP_ID: 101, Event_ID: 1, Member_ID: M1
Row 2: EP_ID: 101, Event_ID: 1, Member_ID: M2
Row 3: EP_ID: 101, Event_ID: 1, Member_ID: M3
Row 4: EP_ID: 102, Event_ID: 1, Member_ID: M1
Row 5: EP_ID: 102, Event_ID: 1, Member_ID: M2
Row 6: EP_ID: 102, Event_ID: 1, Member_ID: M3

즉, EventParticipant(EP)를 조회하면서 ep_id 별로 member_id가 중복되는데, 기존에 캐싱한 Event에 중복된 member_id가 add되어 멤버 중복 문제가 발생한 것으로 파악됩니다.

따라서 EventParticipant를 조회할 때 User만 조회하고, Member는 Event에서만 조회하도록 하였습니다.

---

## 📝️ 관련 이슈

- Fixes : #322 

---

## 💬 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 최적화에 중점을 두었으며, 최종 사용자에게 직접적인 영향을 미치는 새로운 기능이나 버그 수정은 포함되어 있지 않습니다.

* **Refactor**
  * 데이터 조회 성능 개선을 위한 내부 쿼리 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->