### PR TITLE
fix: (#350) 메일 발행 시 saveAll 배치 저장 및 도메인 이벤트를 활용한 비동기 처리 방식으로 변경한다

### DIFF
--- a/src/main/java/side/onetime/global/config/AsyncConfig.java
+++ b/src/main/java/side/onetime/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package side.onetime.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/side/onetime/service/EmailEventListener.java
+++ b/src/main/java/side/onetime/service/EmailEventListener.java
@@ -1,0 +1,22 @@
+package side.onetime.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import side.onetime.dto.admin.email.request.EmailEventMessage;
+
+@Component
+@RequiredArgsConstructor
+public class EmailEventListener {
+
+    private final EmailEventPublisher emailEventPublisher;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEmailEvent(EmailEventMessage message) {
+        emailEventPublisher.publish(message);
+    }
+}

--- a/src/main/java/side/onetime/service/EmailEventListener.java
+++ b/src/main/java/side/onetime/service/EmailEventListener.java
@@ -1,7 +1,6 @@
 package side.onetime.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;

--- a/src/main/java/side/onetime/service/EmailService.java
+++ b/src/main/java/side/onetime/service/EmailService.java
@@ -1,34 +1,20 @@
 package side.onetime.service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import side.onetime.domain.AdminUser;
 import side.onetime.domain.EmailLog;
 import side.onetime.domain.EmailTemplate;
 import side.onetime.domain.User;
 import side.onetime.domain.enums.EmailLogStatus;
 import side.onetime.domain.enums.EmailTemplateCode;
-import side.onetime.dto.admin.email.request.CreateEmailTemplateRequest;
-import side.onetime.dto.admin.email.request.EmailEventMessage;
-import side.onetime.dto.admin.email.request.SendEmailRequest;
-import side.onetime.dto.admin.email.request.SendTestEmailRequest;
-import side.onetime.dto.admin.email.request.SendToGroupRequest;
-import side.onetime.dto.admin.email.request.UpdateEmailTemplateRequest;
-import side.onetime.dto.admin.email.response.EmailLogPageResponse;
-import side.onetime.dto.admin.email.response.EmailLogStatsResponse;
-import side.onetime.dto.admin.email.response.EmailTemplateResponse;
-import side.onetime.dto.admin.email.response.SendEmailResponse;
-import side.onetime.dto.admin.email.response.UserEmailDto;
+import side.onetime.dto.admin.email.request.*;
+import side.onetime.dto.admin.email.response.*;
 import side.onetime.exception.CustomException;
 import side.onetime.exception.status.EmailErrorStatus;
 import side.onetime.global.common.status.ErrorStatus;
@@ -37,6 +23,11 @@ import side.onetime.repository.EmailLogRepository;
 import side.onetime.repository.EmailTemplateRepository;
 import side.onetime.repository.StatisticsRepository;
 import side.onetime.util.AdminAuthorizationUtil;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 이메일 서비스
@@ -47,7 +38,7 @@ import side.onetime.util.AdminAuthorizationUtil;
 @RequiredArgsConstructor
 public class EmailService {
 
-    private final EmailEventPublisher emailEventPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final AdminRepository adminRepository;
     private final StatisticsRepository statisticsRepository;
     private final EmailLogRepository emailLogRepository;
@@ -58,13 +49,25 @@ public class EmailService {
      */
     @Transactional
     public SendEmailResponse sendEmail(SendEmailRequest request) {
+        List<EmailLog> emailLogs = new ArrayList<>();
         List<EmailEventMessage.Recipient> recipients = new ArrayList<>();
+        
         for (int i = 0; i < request.to().size(); i++) {
             String email = request.to().get(i);
             Long userId = request.getUserIdAt(i);
 
-            EmailLog emailLog = saveQueuedEmailLog(userId, email, request.subject(),
+            EmailLog emailLog = createQueuedEmailLog(userId, email, request.subject(),
                     request.content(), request.getContentType(), null);
+            emailLogs.add(emailLog);
+        }
+        
+        emailLogRepository.saveAll(emailLogs);
+
+        for (int i = 0; i < emailLogs.size(); i++) {
+            EmailLog emailLog = emailLogs.get(i);
+            String email = request.to().get(i);
+            Long userId = request.getUserIdAt(i);
+            
             recipients.add(new EmailEventMessage.Recipient(
                     emailLog.getId(), email, userId, null, null));
         }
@@ -72,7 +75,7 @@ public class EmailService {
         EmailEventMessage message = EmailEventMessage.of(
                 request.subject(), request.content(), request.getContentType(),
                 null, recipients);
-        emailEventPublisher.publish(message);
+        applicationEventPublisher.publishEvent(message);
 
         log.info("[Email] SQS 발행 완료 - {}건 QUEUED", recipients.size());
         return SendEmailResponse.queued(recipients.size());
@@ -88,8 +91,9 @@ public class EmailService {
         AdminUser admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorStatus._UNIDENTIFIED_USER));
 
-        EmailLog emailLog = saveQueuedEmailLog(adminId, admin.getEmail(),
+        EmailLog emailLog = createQueuedEmailLog(adminId, admin.getEmail(),
                 request.subject(), request.content(), request.getContentType(), "test");
+        emailLogRepository.save(emailLog);
 
         List<EmailEventMessage.Recipient> recipients = List.of(
                 new EmailEventMessage.Recipient(
@@ -99,7 +103,7 @@ public class EmailService {
         EmailEventMessage message = EmailEventMessage.of(
                 request.subject(), request.content(), request.getContentType(),
                 "test", recipients);
-        emailEventPublisher.publish(message);
+        applicationEventPublisher.publishEvent(message);
 
         log.info("[Email] 테스트 이메일 SQS 발행 완료 - 수신자: {}", admin.getEmail());
         return SendEmailResponse.queued(1);
@@ -118,11 +122,21 @@ public class EmailService {
             return SendEmailResponse.empty();
         }
 
-        List<EmailEventMessage.Recipient> recipients = new ArrayList<>();
+        List<EmailLog> emailLogs = new ArrayList<>();
         for (UserEmailDto user : users) {
-            EmailLog emailLog = saveQueuedEmailLog(user.userId(), user.email(),
+            EmailLog emailLog = createQueuedEmailLog(user.userId(), user.email(),
                     request.subject(), request.content(), request.getContentType(),
                     request.targetGroup());
+            emailLogs.add(emailLog);
+        }
+        
+        emailLogRepository.saveAll(emailLogs);
+
+        List<EmailEventMessage.Recipient> recipients = new ArrayList<>();
+        for (int i = 0; i < users.size(); i++) {
+            UserEmailDto user = users.get(i);
+            EmailLog emailLog = emailLogs.get(i);
+            
             recipients.add(new EmailEventMessage.Recipient(
                     emailLog.getId(), user.email(), user.userId(),
                     user.name(), user.nickname()));
@@ -131,7 +145,7 @@ public class EmailService {
         EmailEventMessage message = EmailEventMessage.of(
                 request.subject(), request.content(), request.getContentType(),
                 request.targetGroup(), recipients);
-        emailEventPublisher.publish(message);
+        applicationEventPublisher.publishEvent(message);
 
         log.info("[Email] 그룹 이메일 SQS 발행 완료 - 그룹: {}, {}건 QUEUED",
                 request.targetGroup(), recipients.size());
@@ -141,9 +155,9 @@ public class EmailService {
     /**
      * QUEUED 상태 이메일 로그 저장
      */
-    private EmailLog saveQueuedEmailLog(Long userId, String recipient, String subject,
+    private EmailLog createQueuedEmailLog(Long userId, String recipient, String subject,
                                          String content, String contentType, String targetGroup) {
-        EmailLog emailLog = EmailLog.builder()
+        return EmailLog.builder()
                 .userId(userId)
                 .recipient(recipient)
                 .subject(subject)
@@ -152,7 +166,6 @@ public class EmailService {
                 .status(EmailLogStatus.QUEUED)
                 .targetGroup(targetGroup)
                 .build();
-        return emailLogRepository.save(emailLog);
     }
 
     /**
@@ -183,9 +196,10 @@ public class EmailService {
         EmailTemplate template = emailTemplateRepository.findByCode(templateCode)
                 .orElseThrow(() -> new CustomException(EmailErrorStatus._EMAIL_TEMPLATE_NOT_FOUND));
 
-        EmailLog emailLog = saveQueuedEmailLog(
+        EmailLog emailLog = createQueuedEmailLog(
                 user.getId(), user.getEmail(), template.getSubject(),
                 template.getContent(), template.getContentType(), templateCode);
+        emailLogRepository.save(emailLog);
 
         List<EmailEventMessage.Recipient> recipients = List.of(
                 new EmailEventMessage.Recipient(
@@ -195,7 +209,7 @@ public class EmailService {
         EmailEventMessage message = EmailEventMessage.of(
                 template.getSubject(), template.getContent(), template.getContentType(),
                 templateCode, recipients);
-        emailEventPublisher.publish(message);
+        applicationEventPublisher.publishEvent(message);
 
         log.info("[Email] 웰컴 이메일 SQS 발행 - userId: {}", user.getId());
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ spring:
       s3:
         bucket: ${S3_BUCKET_NAME}
       sqs:
-        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL:}
+        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL}
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
- 온보딩 트랜잭션 커밋 후 메일을 발송하도록 변경했습니다.

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- 온보딩 시 메일 발송에서 오류가 발생할 경우, 메일 발송 로직의 트랜잭션에서 rollback 마킹되어 온보딩 과정이 수행되지 않고 있습니다.
- 다수의 메일을 보낼 경우, 단건 씩 save되고 있습니다.

## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- 온보딩 트랜잭션 커밋 이후 메일을 발송하도록 했습니다.
- EmailLog는 saveAll 방식으로 변경했습니다.
- 비동기로 메일을 보내도록 변경했습니다.

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  - 이메일 처리가 비동기 이벤트 방식으로 전환되어 트랜잭션 커밋 이후 비동기 처리됨
  - 대량 이메일 전송 시 이메일 로그를 일괄 저장하여 저장 효율 및 성능 개선
  - 환영 이메일 로그 저장 흐름이 명시적으로 변경됨
  - AWS SQS 구성의 해당 환경 변수 값이 필수화되어 설정 요구사항이 명확해짐
<!-- end of auto-generated comment: release notes by coderabbit.ai -->