### PR TITLE
fix: (#352) 온보딩 동시 요청 시 발생하는 중복 가입 500 에러를 예외 처리한다

### DIFF
--- a/src/main/java/side/onetime/service/UserService.java
+++ b/src/main/java/side/onetime/service/UserService.java
@@ -1,29 +1,16 @@
 package side.onetime.service;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import side.onetime.domain.GuideViewLog;
 import side.onetime.domain.RefreshToken;
 import side.onetime.domain.User;
 import side.onetime.domain.enums.GuideType;
-import side.onetime.dto.user.request.CreateGuideViewLogRequest;
-import side.onetime.dto.user.request.LogoutUserRequest;
-import side.onetime.dto.user.request.OnboardUserRequest;
-import side.onetime.dto.user.request.UpdateUserPolicyAgreementRequest;
-import side.onetime.dto.user.request.UpdateUserProfileRequest;
-import side.onetime.dto.user.request.UpdateUserSleepTimeRequest;
-import side.onetime.dto.user.response.GetGuideViewLogResponse;
-import side.onetime.dto.user.response.GetUserPolicyAgreementResponse;
-import side.onetime.dto.user.response.GetUserProfileResponse;
-import side.onetime.dto.user.response.GetUserSleepTimeResponse;
-import side.onetime.dto.user.response.OnboardUserResponse;
+import side.onetime.dto.user.request.*;
+import side.onetime.dto.user.response.*;
 import side.onetime.exception.CustomException;
 import side.onetime.exception.status.UserErrorStatus;
 import side.onetime.repository.GuideViewLogRepository;
@@ -31,6 +18,10 @@ import side.onetime.repository.RefreshTokenRepository;
 import side.onetime.repository.UserRepository;
 import side.onetime.util.JwtUtil;
 import side.onetime.util.UserAuthorizationUtil;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -65,7 +56,11 @@ public class UserService {
         }
 
         User newUser = createUserFromRegisterToken(request, registerToken);
-        userRepository.save(newUser);
+        try {
+            userRepository.save(newUser);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(UserErrorStatus._ALREADY_REGISTERED_USER);
+        }
 
         // 웰컴 이메일 SQS 발행 (실패해도 가입은 정상 완료)
         try {


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
- 온보딩 동시 요청 시 DB 유니크 제약 조건으로 발생한 에러를 사용자 커스텀 예외(`_ALREADY_REGISTERED_USER`)로 처리한다.

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- 현재 온보딩 시 특정 상황에서 동시 요청이 발생하여 500 에러 (DB 제약조건 위반) 발생
- DB 에러를 따로 처리하고 있지 않고 있음 


## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- DB 에러를 캐치해서 사용자 커스텀 예외(`_ALREADY_REGISTERED_USER`)로 반환


---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 등록 중 중복된 가입 정보 발생 시 오류가 적절하게 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->