### PR TITLE
feat: (#354) 이벤트 확정일자를 톡캘린더에 등록하는 기능을 구현한다

### DIFF
--- a/src/main/java/side/onetime/controller/KakaoController.java
+++ b/src/main/java/side/onetime/controller/KakaoController.java
@@ -1,0 +1,70 @@
+package side.onetime.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+import side.onetime.auth.annotation.PublicApi;
+import side.onetime.dto.kakao.api.KakaoCalendarEventResponse;
+import side.onetime.dto.kakao.request.CreateKakaoCalendarEventRequest;
+import side.onetime.dto.kakao.request.KakaoTokenRequest;
+import side.onetime.dto.kakao.response.KakaoTokenResponse;
+import side.onetime.global.common.ApiResponse;
+import side.onetime.global.common.status.SuccessStatus;
+import side.onetime.service.KakaoService;
+
+@RestController
+@RequestMapping("/api/v1/kakao")
+@RequiredArgsConstructor
+public class KakaoController {
+
+    private final KakaoService kakaoService;
+
+    /**
+     * 카카오 인증 페이지 URL 조회 API.
+     *
+     * 프론트엔드에서 카카오 로그인을 통해 'talk_calendar' 권한을 요청할 수 있는 인가 코드 발급용 URL로 리다이렉트합니다.
+     *
+     * @return 카카오 OAuth 인증 페이지로의 RedirectView
+     */
+    @PublicApi
+    @GetMapping("/authorize-url")
+    public RedirectView getAuthorizeUrl() {
+        return new RedirectView(kakaoService.getAuthorizeUrl());
+    }
+
+    /**
+     * 카카오 액세스 토큰 발급 API.
+     *
+     * 전달받은 인가 코드(code)를 사용하여 카카오로부터 액세스 토큰을 발급받습니다.
+     * 발급받은 토큰은 이후 톡캘린더 API 호출 시 사용됩니다.
+     *
+     * @param request 인가 코드가 포함된 요청 객체
+     * @return 발급된 카카오 토큰 정보 (accessToken)
+     */
+    @PublicApi
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<KakaoTokenResponse>> getKakaoToken(@RequestBody @Valid KakaoTokenRequest request) {
+        KakaoTokenResponse response = kakaoService.getKakaoToken(request.code());
+        return ApiResponse.onSuccess(SuccessStatus._CREATE_KAKAO_TOKEN, response);
+    }
+
+    /**
+     * 카카오 톡캘린더 일정 생성 API.
+     *
+     * 확정된 이벤트 정보를 바탕으로 사용자의 카카오 톡캘린더에 새로운 일정을 생성합니다.
+     * 이 API를 호출하기 위해서는 이전에 발급받은 카카오 액세스 토큰이 필요합니다.
+     *
+     * @param request 액세스 토큰과 서비스 내 이벤트 ID가 포함된 요청 객체
+     * @return 생성된 카카오 캘린더 이벤트의 ID 정보
+     */
+    @PublicApi
+    @PostMapping("/calendar/confirmation")
+    public ResponseEntity<ApiResponse<KakaoCalendarEventResponse>> createCalendarEvent(
+            @RequestBody @Valid CreateKakaoCalendarEventRequest request
+    ) {
+        KakaoCalendarEventResponse response = kakaoService.createCalendarEvent(request);
+        return ApiResponse.onSuccess(SuccessStatus._CREATE_KAKAO_CALENDAR_EVENT, response);
+    }
+}

--- a/src/main/java/side/onetime/dto/kakao/api/KakaoCalendarEventDto.java
+++ b/src/main/java/side/onetime/dto/kakao/api/KakaoCalendarEventDto.java
@@ -1,0 +1,47 @@
+package side.onetime.dto.kakao.api;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 카카오 톡캘린더 이벤트 생성 요청 시 'event' 파라미터에 들어갈 데이터 구조입니다.
+ */
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoCalendarEventDto(
+        String title,
+        KakaoCalendarTimeDto time,
+        String description,
+        List<Integer> reminders,
+        String color,
+        String rrule
+) {
+    @Builder
+    public KakaoCalendarEventDto {
+        if (description == null) {
+            description = "OneTime에 의해 추가된 일정입니다.";
+        }
+        if (reminders == null) {
+            reminders = List.of(30, 1440);
+        }
+        if (color == null) {
+            color = "LAVENDER";
+        }
+    }
+
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record KakaoCalendarTimeDto(
+            String startAt,
+            String endAt,
+            String timeZone
+    ) {
+        @Builder
+        public KakaoCalendarTimeDto {
+            if (timeZone == null) {
+                timeZone = "Asia/Seoul";
+            }
+        }
+    }
+}

--- a/src/main/java/side/onetime/dto/kakao/api/KakaoCalendarEventResponse.java
+++ b/src/main/java/side/onetime/dto/kakao/api/KakaoCalendarEventResponse.java
@@ -1,0 +1,10 @@
+package side.onetime.dto.kakao.api;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoCalendarEventResponse(
+        String eventId
+) {
+}

--- a/src/main/java/side/onetime/dto/kakao/request/CreateKakaoCalendarEventRequest.java
+++ b/src/main/java/side/onetime/dto/kakao/request/CreateKakaoCalendarEventRequest.java
@@ -1,0 +1,23 @@
+package side.onetime.dto.kakao.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.UUID;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CreateKakaoCalendarEventRequest(
+        @NotBlank(message = "액세스 토큰은 필수입니다.")
+        String accessToken,
+        @NotNull(message = "이벤트 ID는 필수입니다.")
+        UUID eventId,
+        String description,
+        List<Integer> reminders,
+        String color,
+        String rrule,
+        String timeZone
+) {
+}

--- a/src/main/java/side/onetime/dto/kakao/request/KakaoTokenRequest.java
+++ b/src/main/java/side/onetime/dto/kakao/request/KakaoTokenRequest.java
@@ -1,0 +1,13 @@
+package side.onetime.dto.kakao.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import jakarta.validation.constraints.NotBlank;
+
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoTokenRequest(
+        @NotBlank(message = "인가 코드는 필수입니다.")
+        String code
+) {
+}

--- a/src/main/java/side/onetime/dto/kakao/response/KakaoTokenResponse.java
+++ b/src/main/java/side/onetime/dto/kakao/response/KakaoTokenResponse.java
@@ -1,0 +1,10 @@
+package side.onetime.dto.kakao.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoTokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/side/onetime/exception/status/EventErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/EventErrorStatus.java
@@ -18,6 +18,8 @@ public enum EventErrorStatus implements BaseErrorCode {
     _CANNOT_MODIFY_CONFIRMED_EVENT(HttpStatus.CONFLICT, "EVENT-007", "확정된 이벤트는 수정할 수 없습니다."),
     _NOT_FOUND_EVENT_CONFIRMATION(HttpStatus.NOT_FOUND, "EVENT-008", "확정된 이벤트 정보를 찾을 수 없습니다."),
     _FAILED_SERIALIZE_KAKAO_EVENT(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-009", "카카오 일정 정보를 처리하는 중 오류가 발생했습니다."),
+    _KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-010", "카카오 토큰 발급에 실패했습니다."),
+    _KAKAO_CALENDAR_API_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-011", "카카오 톡캘린더 API 호출에 실패했습니다 ."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/exception/status/EventErrorStatus.java
+++ b/src/main/java/side/onetime/exception/status/EventErrorStatus.java
@@ -1,9 +1,8 @@
 package side.onetime.exception.status;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import side.onetime.global.common.code.BaseErrorCode;
 import side.onetime.global.common.dto.ErrorReasonDto;
 
@@ -17,6 +16,8 @@ public enum EventErrorStatus implements BaseErrorCode {
     _FAILED_GENERATE_QR_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-005", "QR 코드를 생성하고 업로드 하는 과정에서 문제가 발생했습니다."),
     _INVALID_CONFIRMATION_REQUEST(HttpStatus.BAD_REQUEST, "EVENT-006", "유효하지 않은 확정 요청입니다."),
     _CANNOT_MODIFY_CONFIRMED_EVENT(HttpStatus.CONFLICT, "EVENT-007", "확정된 이벤트는 수정할 수 없습니다."),
+    _NOT_FOUND_EVENT_CONFIRMATION(HttpStatus.NOT_FOUND, "EVENT-008", "확정된 이벤트 정보를 찾을 수 없습니다."),
+    _FAILED_SERIALIZE_KAKAO_EVENT(HttpStatus.INTERNAL_SERVER_ERROR, "EVENT-009", "카카오 일정 정보를 처리하는 중 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/global/common/status/SuccessStatus.java
+++ b/src/main/java/side/onetime/global/common/status/SuccessStatus.java
@@ -113,6 +113,10 @@ public enum SuccessStatus implements BaseCode {
     _CREATE_EMAIL_TEMPLATE(HttpStatus.CREATED, "201", "이메일 템플릿 생성에 성공했습니다."),
     _UPDATE_EMAIL_TEMPLATE(HttpStatus.OK, "200", "이메일 템플릿 수정에 성공했습니다."),
     _DELETE_EMAIL_TEMPLATE(HttpStatus.OK, "200", "이메일 템플릿 삭제에 성공했습니다."),
+    // Kakao
+    _GET_KAKAO_AUTHORIZE_URL(HttpStatus.OK, "200", "카카오 인증 URL 조회에 성공했습니다."),
+    _CREATE_KAKAO_TOKEN(HttpStatus.OK, "200", "카카오 토큰 발급에 성공했습니다."),
+    _CREATE_KAKAO_CALENDAR_EVENT(HttpStatus.CREATED, "201", "카카오 캘린더 일정 생성에 성공했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/side/onetime/global/config/SecurityConfig.java
+++ b/src/main/java/side/onetime/global/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 		"/api/v1/schedules/**",         // 스케줄 조회
 		"/api/v1/banners/activated/all",
 		"/api/v1/bar-banners/activated/all",
+		"/api/v1/kakao/authorize-url"
 	};
 	
 	/**
@@ -77,6 +78,7 @@ public class SecurityConfig {
 		"/api/v1/schedules/date/*/filtering",     // 스케줄 필터링
         "/api/v1/banners/staging",
         "/api/v1/bar-banners/staging",
+        "/api/v1/kakao/**",
 	};
 
 	/**

--- a/src/main/java/side/onetime/global/config/SecurityConfig.java
+++ b/src/main/java/side/onetime/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package side.onetime.global.config;
 
-import java.util.Arrays;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -17,13 +16,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import lombok.RequiredArgsConstructor;
 import side.onetime.auth.exception.CustomAccessDeniedHandler;
 import side.onetime.auth.exception.CustomAuthenticationEntryPoint;
 import side.onetime.auth.handler.OAuthLoginFailureHandler;
 import side.onetime.auth.handler.OAuthLoginSuccessHandler;
 import side.onetime.global.filter.JwtFilter;
+
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Configuration
@@ -54,7 +53,7 @@ public class SecurityConfig {
 		"/api/v1/schedules/**",         // 스케줄 조회
 		"/api/v1/banners/activated/all",
 		"/api/v1/bar-banners/activated/all",
-		"/api/v1/kakao/authorize-url"
+		"/api/v1/kakao/authorize-url",
 	};
 	
 	/**
@@ -78,7 +77,8 @@ public class SecurityConfig {
 		"/api/v1/schedules/date/*/filtering",     // 스케줄 필터링
         "/api/v1/banners/staging",
         "/api/v1/bar-banners/staging",
-        "/api/v1/kakao/**",
+        "/api/v1/kakao/token",
+        "/api/v1/kakao/calendar/confirmation",
 	};
 
 	/**

--- a/src/main/java/side/onetime/infra/kakao/client/KakaoApiClient.java
+++ b/src/main/java/side/onetime/infra/kakao/client/KakaoApiClient.java
@@ -1,0 +1,31 @@
+package side.onetime.infra.kakao.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import side.onetime.dto.kakao.api.KakaoCalendarEventResponse;
+
+@FeignClient(
+    name = "kakaoApiClient",
+    url = "https://kapi.kakao.com"
+)
+public interface KakaoApiClient {
+
+    /**
+     * 카카오 톡캘린더 이벤트를 생성합니다.
+     *
+     * @param accessToken "Bearer {token}" 형식의 카카오 액세스 토큰
+     * @param eventJson JSON 문자열로 직렬화된 이벤트 데이터 (KakaoCalendarEventDto 규격)
+     * @return 생성된 이벤트의 식별 정보 (event_id)
+     */
+    @PostMapping(
+        value = "/v2/api/calendar/create/event",
+        consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+    )
+    KakaoCalendarEventResponse createTalkCalendarEvent(
+        @RequestHeader("Authorization") String accessToken,
+        @RequestParam("event") String eventJson
+    );
+}

--- a/src/main/java/side/onetime/infra/kakao/client/KakaoAuthClient.java
+++ b/src/main/java/side/onetime/infra/kakao/client/KakaoAuthClient.java
@@ -1,0 +1,36 @@
+package side.onetime.infra.kakao.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import side.onetime.dto.kakao.response.KakaoTokenResponse;
+
+@FeignClient(
+    name = "kakaoAuthClient",
+    url = "https://kauth.kakao.com"
+)
+public interface KakaoAuthClient {
+
+    /**
+     * 카카오 OAuth 토큰을 발급받습니다.
+     *
+     * @param grantType 권한 부여 방식 (이 메서드에서는 "authorization_code")
+     * @param clientId 카카오 앱의 REST API 키
+     * @param redirectUri 카카오 로그인 시 설정했던 Redirect URI
+     * @param code 사용자로부터 받은 인가 코드
+     * @param clientSecret 카카오 앱의 Client Secret
+     * @return 액세스 토큰 및 리프레시 토큰 정보가 담긴 응답 DTO
+     */
+    @PostMapping(
+        value = "/oauth/token",
+        consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+    )
+    KakaoTokenResponse getAccessToken(
+        @RequestParam("grant_type") String grantType,
+        @RequestParam("client_id") String clientId,
+        @RequestParam("redirect_uri") String redirectUri,
+        @RequestParam("code") String code,
+        @RequestParam("client_secret") String clientSecret
+    );
+}

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -1,67 +1,34 @@
 package side.onetime.service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import lombok.RequiredArgsConstructor;
-import side.onetime.domain.Event;
-import side.onetime.domain.EventConfirmation;
-import side.onetime.domain.EventParticipation;
-import side.onetime.domain.Member;
-import side.onetime.domain.Schedule;
-import side.onetime.domain.Selection;
-import side.onetime.domain.User;
+import side.onetime.domain.*;
 import side.onetime.domain.enums.Category;
 import side.onetime.domain.enums.EventStatus;
 import side.onetime.domain.enums.ParticipationRole;
 import side.onetime.dto.event.request.ConfirmEventRequest;
 import side.onetime.dto.event.request.CreateEventRequest;
 import side.onetime.dto.event.request.ModifyEventRequest;
-import side.onetime.dto.event.response.ConfirmEventResponse;
-import side.onetime.dto.event.response.CreateEventResponse;
-import side.onetime.dto.event.response.GetEventQrCodeResponse;
-import side.onetime.dto.event.response.GetEventResponse;
-import side.onetime.dto.event.response.GetMostPossibleTime;
-import side.onetime.dto.event.response.GetParticipantsResponse;
-import side.onetime.dto.event.response.GetParticipatedEventResponse;
-import side.onetime.dto.event.response.GetParticipatedEventsResponse;
-import side.onetime.dto.event.response.PageCursorInfo;
+import side.onetime.dto.event.response.*;
 import side.onetime.dto.schedule.request.GetFilteredSchedulesRequest;
 import side.onetime.exception.CustomException;
 import side.onetime.exception.status.EventErrorStatus;
 import side.onetime.exception.status.EventParticipationErrorStatus;
 import side.onetime.exception.status.ScheduleErrorStatus;
 import side.onetime.exception.status.UserErrorStatus;
-import side.onetime.repository.EventConfirmationRepository;
-import side.onetime.repository.EventParticipationRepository;
-import side.onetime.repository.EventRepository;
-import side.onetime.repository.ScheduleBatchRepository;
-import side.onetime.repository.ScheduleRepository;
-import side.onetime.repository.SelectionRepository;
-import side.onetime.repository.UserRepository;
-import side.onetime.util.DateUtil;
-import side.onetime.util.JwtUtil;
-import side.onetime.util.QrUtil;
-import side.onetime.util.S3Util;
-import side.onetime.util.UserAuthorizationUtil;
+import side.onetime.repository.*;
+import side.onetime.util.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static side.onetime.util.DateUtil.DAY_ORDER;
 
 
 @Service
@@ -69,9 +36,6 @@ import side.onetime.util.UserAuthorizationUtil;
 public class EventService {
 
     private static final int MAX_MOST_POSSIBLE_TIMES_SIZE = 10;
-    private static final Map<String, Integer> DAY_ORDER = Map.of(
-            "일", 0, "월", 1, "화", 2, "수", 3, "목", 4, "금", 5, "토", 6
-    );
     
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
@@ -220,18 +184,9 @@ public class EventService {
 
         // 2. 시간 유효성 검증: 같은 날짜/요일인 경우에만 startTime < endTime을 검증한다.
         //    날짜/요일이 다르면 시간이 역전되어도 유효하다. (예: 03.03 01:30 ~ 03.04 00:30)
-        if (isSamePeriod && parseTimeSafe(request.startTime()) >= parseTimeSafe(request.endTime())) {
+        if (isSamePeriod && DateUtil.parseTimeMinutes(request.startTime()) >= DateUtil.parseTimeMinutes(request.endTime())) {
             throw new CustomException(EventErrorStatus._INVALID_CONFIRMATION_REQUEST);
         }
-    }
-
-    /**
-     * 시간 문자열을 분 단위 정수로 변환한다. "24:00"은 LocalTime으로 파싱할 수 없으므로 1440으로 처리한다.
-     */
-    private int parseTimeSafe(String time) {
-        if ("24:00".equals(time)) return 1440;
-        LocalTime parsed = DateUtil.parseTime(time);
-        return parsed.getHour() * 60 + parsed.getMinute();
     }
 
     /**

--- a/src/main/java/side/onetime/service/KakaoService.java
+++ b/src/main/java/side/onetime/service/KakaoService.java
@@ -1,0 +1,141 @@
+package side.onetime.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+import side.onetime.domain.Event;
+import side.onetime.domain.EventConfirmation;
+import side.onetime.domain.enums.Category;
+import side.onetime.dto.kakao.api.KakaoCalendarEventDto;
+import side.onetime.dto.kakao.api.KakaoCalendarEventResponse;
+import side.onetime.dto.kakao.request.CreateKakaoCalendarEventRequest;
+import side.onetime.dto.kakao.response.KakaoTokenResponse;
+import side.onetime.exception.CustomException;
+import side.onetime.exception.status.EventErrorStatus;
+import side.onetime.infra.kakao.client.KakaoApiClient;
+import side.onetime.infra.kakao.client.KakaoAuthClient;
+import side.onetime.repository.EventConfirmationRepository;
+import side.onetime.repository.EventRepository;
+import side.onetime.util.DateUtil;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
+    private final ObjectMapper objectMapper;
+    private final EventRepository eventRepository;
+    private final EventConfirmationRepository eventConfirmationRepository;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${app.kakao.calendar-redirect-uri}")
+    private String calendarRedirectUri;
+
+    /**
+     * 카카오 인증 페이지 리다이렉트 메서드.
+     *
+     * 프론트엔드에서 카카오 로그인을 통해 'talk_calendar' 권한을 요청할 수 있는 인가 코드 발급용 URL입니다.
+     *
+     * @return 카카오 OAuth 인증 페이지 URL
+     */
+    public String getAuthorizeUrl() {
+        return UriComponentsBuilder.fromHttpUrl("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", calendarRedirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", "talk_calendar")
+                .build()
+                .toUriString();
+    }
+
+    /**
+     * 카카오 액세스 토큰 발급 메서드.
+     *
+     * 전달받은 인가 코드를 사용하여 카카오로부터 액세스 토큰 정보를 가져옵니다.
+     *
+     * @param code 카카오로부터 전달받은 인가 코드
+     * @return 카카오 토큰 응답 (accessToken)
+     */
+    public KakaoTokenResponse getKakaoToken(String code) {
+        return kakaoAuthClient.getAccessToken(
+                "authorization_code",
+                clientId,
+                calendarRedirectUri,
+                code,
+                clientSecret
+        );
+    }
+
+    /**
+     * 카카오 톡캘린더에 일정을 생성하는 메서드.
+     *
+     * 확정한 이벤트 정보(제목, 확정 시간 등)를 바탕으로 사용자의 카카오 캘린더에 일정을 등록합니다.
+     * 카카오 API 호출을 위해 유효한 액세스 토큰이 필요합니다.
+     *
+     * @param request     톡캘린더에 등록할 이벤트 요청 객체
+     * @return 생성된 일정 정보 (event_id 등)
+     * @throws CustomException 이벤트를 찾을 수 없거나, 확정 정보가 없거나, JSON 직렬화에 실패한 경우
+     */
+    public KakaoCalendarEventResponse createCalendarEvent(CreateKakaoCalendarEventRequest request) {
+        Event event = eventRepository.findByEventId(request.eventId())
+                .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
+        EventConfirmation confirmation = eventConfirmationRepository.findByEventId(event.getId())
+                .orElseThrow(() -> new CustomException(EventErrorStatus._NOT_FOUND_EVENT_CONFIRMATION));
+
+        KakaoCalendarEventDto eventDto = buildKakaoCalendarEventDto(event, confirmation, request);
+
+        try {
+            String eventJson = objectMapper.writeValueAsString(eventDto);
+            return kakaoApiClient.createTalkCalendarEvent("Bearer " + request.accessToken(), eventJson);
+        } catch (JsonProcessingException e) {
+            throw new CustomException(EventErrorStatus._FAILED_SERIALIZE_KAKAO_EVENT);
+        }
+    }
+
+    /**
+     * 카카오 캘린더 API 요청을 위한 DTO를 구성합니다.
+     * 
+     * 확정된 이벤트의 카테고리(날짜/요일)에 따라 시작 시간과 종료 시간을 포맷팅하고,
+     * 요일 기반 이벤트의 경우 반복 설정(RRULE)을 추가합니다.
+     *
+     * @param event        이벤트 엔티티
+     * @param confirmation 이벤트 확정 정보 엔티티
+     * @return 카카오 캘린더 API 규격에 맞춘 DTO
+     */
+    private KakaoCalendarEventDto buildKakaoCalendarEventDto(Event event, EventConfirmation confirmation, CreateKakaoCalendarEventRequest request) {
+        Category category = event.getCategory();
+
+        String startAt = DateUtil.formatToIsoDateTime(category,
+                (category == Category.DATE) ? confirmation.getStartDate() : confirmation.getStartDay(),
+                confirmation.getStartTime());
+
+        String endAt = DateUtil.formatToIsoDateTime(category,
+                (category == Category.DATE) ? confirmation.getEndDate() : confirmation.getEndDay(),
+                confirmation.getEndTime());
+
+        String rrule = (request.rrule() != null) ? request.rrule() :
+                ((category == Category.DAY) ? "FREQ=WEEKLY" : null);
+
+        return KakaoCalendarEventDto.builder()
+                .title(event.getTitle())
+                .time(KakaoCalendarEventDto.KakaoCalendarTimeDto.builder()
+                        .startAt(startAt)
+                        .endAt(endAt)
+                        .timeZone(request.timeZone())
+                        .build())
+                .description(request.description())
+                .reminders(request.reminders())
+                .color(request.color())
+                .rrule(rrule)
+                .build();
+    }
+}

--- a/src/main/java/side/onetime/service/KakaoService.java
+++ b/src/main/java/side/onetime/service/KakaoService.java
@@ -2,7 +2,9 @@ package side.onetime.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,6 +23,7 @@ import side.onetime.repository.EventConfirmationRepository;
 import side.onetime.repository.EventRepository;
 import side.onetime.util.DateUtil;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoService {
@@ -66,13 +69,18 @@ public class KakaoService {
      * @return 카카오 토큰 응답 (accessToken)
      */
     public KakaoTokenResponse getKakaoToken(String code) {
-        return kakaoAuthClient.getAccessToken(
-                "authorization_code",
-                clientId,
-                calendarRedirectUri,
-                code,
-                clientSecret
-        );
+        try {
+            return kakaoAuthClient.getAccessToken(
+                    "authorization_code",
+                    clientId,
+                    calendarRedirectUri,
+                    code,
+                    clientSecret
+            );
+        } catch (FeignException e) {
+            log.error("[Kakao] 토큰 발급 실패 - status: {}, body: {}", e.status(), e.contentUTF8(), e);
+            throw new CustomException(EventErrorStatus._KAKAO_TOKEN_REQUEST_FAILED);
+        }
     }
 
     /**
@@ -98,12 +106,15 @@ public class KakaoService {
             return kakaoApiClient.createTalkCalendarEvent("Bearer " + request.accessToken(), eventJson);
         } catch (JsonProcessingException e) {
             throw new CustomException(EventErrorStatus._FAILED_SERIALIZE_KAKAO_EVENT);
+        } catch (FeignException e) {
+            log.error("[Kakao] 톡캘린더 일정 생성 실패 - status: {}, body: {}", e.status(), e.contentUTF8(), e);
+            throw new CustomException(EventErrorStatus._KAKAO_CALENDAR_API_FAILED);
         }
     }
 
     /**
      * 카카오 캘린더 API 요청을 위한 DTO를 구성합니다.
-     * 
+     *
      * 확정된 이벤트의 카테고리(날짜/요일)에 따라 시작 시간과 종료 시간을 포맷팅하고,
      * 요일 기반 이벤트의 경우 반복 설정(RRULE)을 추가합니다.
      *

--- a/src/main/java/side/onetime/util/DateUtil.java
+++ b/src/main/java/side/onetime/util/DateUtil.java
@@ -285,8 +285,14 @@ public class DateUtil {
                 ? parseDate(dateOrDay)
                 : getNextDateForDay(dateOrDay);
 
-        LocalTime time = parseTime(timeStr);
-        return LocalDateTime.of(date, time)
+        LocalDateTime dateTime;
+        if ("24:00".equals(timeStr)) {
+            dateTime = date.plusDays(1).atStartOfDay();
+        } else {
+            dateTime = LocalDateTime.of(date, parseTime(timeStr));
+        }
+
+        return dateTime
                 .atZone(ZoneId.of("Asia/Seoul"))
                 .toOffsetDateTime()
                 .toString();

--- a/src/main/java/side/onetime/util/DateUtil.java
+++ b/src/main/java/side/onetime/util/DateUtil.java
@@ -1,33 +1,28 @@
 package side.onetime.util;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import side.onetime.domain.enums.Category;
+import side.onetime.dto.event.response.GetMostPossibleTime;
+
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
-import side.onetime.domain.enums.Category;
-import side.onetime.dto.event.response.GetMostPossibleTime;
-
-@Component
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DateUtil {
 
     public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static final Map<String, Integer> DAY_ORDER = Map.of(
+            "일", 0, "월", 1, "화", 2, "수", 3, "목", 4, "금", 5, "토", 6
+    );
 
     /**
      * yyyy.MM.dd 형식의 날짜 문자열을 파싱합니다.
@@ -47,6 +42,18 @@ public class DateUtil {
      */
     public static LocalTime parseTime(String timeStr) {
         return LocalTime.parse(timeStr, TIME_FORMATTER);
+    }
+
+    /**
+     * 시간 문자열을 분 단위 정수로 변환합니다. "24:00"은 LocalTime으로 파싱할 수 없으므로 1440으로 처리합니다.
+     *
+     * @param timeStr 시간 문자열 (HH:mm 형식)
+     * @return 분 단위 정수
+     */
+    public static int parseTimeMinutes(String timeStr) {
+        if ("24:00".equals(timeStr)) return 1440;
+        LocalTime parsed = parseTime(timeStr);
+        return parsed.getHour() * 60 + parsed.getMinute();
     }
 
     /**
@@ -243,5 +250,45 @@ public class DateUtil {
      */
     public static String formatToIsoDate(LocalDate date) {
         return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    /**
+     * 한국어 요일명을 바탕으로 현재 시점 기준 가장 가까운(또는 오늘인) 해당 요일의 LocalDate를 반환합니다.
+     *
+     * @param koreanDay 한국어 요일명 (월, 화, 수, 목, 금, 토, 일)
+     * @return 가장 가까운 해당 요일의 LocalDate
+     */
+    public static LocalDate getNextDateForDay(String koreanDay) {
+        DayOfWeek dayOfWeek = switch (koreanDay) {
+            case "월" -> DayOfWeek.MONDAY;
+            case "화" -> DayOfWeek.TUESDAY;
+            case "수" -> DayOfWeek.WEDNESDAY;
+            case "목" -> DayOfWeek.THURSDAY;
+            case "금" -> DayOfWeek.FRIDAY;
+            case "토" -> DayOfWeek.SATURDAY;
+            case "일" -> DayOfWeek.SUNDAY;
+            default -> throw new IllegalArgumentException("지원하지 않는 요일 형식입니다: " + koreanDay);
+        };
+        return LocalDate.now().with(TemporalAdjusters.nextOrSame(dayOfWeek));
+    }
+
+    /**
+     * 날짜 또는 요일을 ISO-8601 형식의 문자열로 변환합니다.
+     *
+     * @param category DATE 또는 DAY 카테고리
+     * @param dateOrDay yyyy.MM.dd 형식의 날짜 또는 한국어 요일 (월, 화...)
+     * @param timeStr HH:mm 형식의 시간
+     * @return ISO-8601 형식의 문자열 (Asia/Seoul 시간대 기준)
+     */
+    public static String formatToIsoDateTime(Category category, String dateOrDay, String timeStr) {
+        LocalDate date = (category == Category.DATE)
+                ? parseDate(dateOrDay)
+                : getNextDateForDay(dateOrDay);
+
+        LocalTime time = parseTime(timeStr);
+        return LocalDateTime.of(date, time)
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .toOffsetDateTime()
+                .toString();
     }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,16 +11,6 @@ spring:
     oauth2:
       client:
         registration:
-          kakao:
-            client-id: ${OAUTH_KAKAO_CLIENT_ID}
-            client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
-            scope:
-              - profile_nickname
-              - account_email
-            authorization-grant-type: authorization_code
-            redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
-            client-name: Kakao
-            client-authentication-method: client_secret_post
           naver:
             client-id: ${OAUTH_NAVER_CLIENT_ID}
             client-secret: ${OAUTH_NAVER_CLIENT_SECRET}
@@ -30,11 +20,6 @@ spring:
             authorization-grant-type: authorization_code
             redirect-uri: ${OAUTH_NAVER_REDIRECT_URI}
         provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,22 @@ spring:
               - email
               - profile
             redirect-uri: ${OAUTH_GOOGLE_REDIRECT_URI}
+          kakao:
+            client-id: ${OAUTH_KAKAO_CLIENT_ID}
+            client-secret: ${OAUTH_KAKAO_CLIENT_SECRET}
+            scope:
+              - profile_nickname
+              - account_email
+            authorization-grant-type: authorization_code
+            redirect-uri: ${OAUTH_KAKAO_REDIRECT_URI}
+            client-name: Kakao
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
   cloud:
     aws:
@@ -103,3 +119,5 @@ app:
   sync:
     target-url: ${APP_SYNC_TARGET_URL:}
     api-key: ${APP_SYNC_API_KEY:}
+  kakao:
+    calendar-redirect-uri: ${OAUTH_KAKAO_CALENDAR_REDIRECT_URI:http://localhost:3000/kakao/callback}

--- a/src/test/java/side/onetime/kakao/KakaoControllerTest.java
+++ b/src/test/java/side/onetime/kakao/KakaoControllerTest.java
@@ -19,6 +19,8 @@ import side.onetime.dto.kakao.api.KakaoCalendarEventResponse;
 import side.onetime.dto.kakao.request.CreateKakaoCalendarEventRequest;
 import side.onetime.dto.kakao.request.KakaoTokenRequest;
 import side.onetime.dto.kakao.response.KakaoTokenResponse;
+import side.onetime.exception.CustomException;
+import side.onetime.exception.status.EventErrorStatus;
 import side.onetime.service.KakaoService;
 
 import java.util.List;
@@ -28,8 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(KakaoController.class)
 public class KakaoControllerTest extends ControllerTestConfig {
@@ -49,8 +50,11 @@ public class KakaoControllerTest extends ControllerTestConfig {
                 .accept(MediaType.APPLICATION_JSON));
 
         // then
+        Mockito.verify(kakaoService).getAuthorizeUrl();
+
         resultActions
                 .andExpect(status().isFound())
+                .andExpect(redirectedUrl(authorizeUrl))
                 .andDo(MockMvcRestDocumentationWrapper.document("kakao/get-authorize-url",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -108,6 +112,42 @@ public class KakaoControllerTest extends ControllerTestConfig {
                                         )
                                         .requestSchema(Schema.schema("KakaoTokenRequestSchema"))
                                         .responseSchema(Schema.schema("KakaoTokenResponseSchema"))
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[FAILED] 카카오 토큰 발급 - 인가 코드 누락")
+    public void getKakaoToken_Fail_MissingCode() throws Exception {
+        // given
+        KakaoTokenRequest request = new KakaoTokenRequest(null);
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/token")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.is_success").value(false))
+                .andExpect(jsonPath("$.code").value("E_BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("인가 코드는 필수입니다."))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/get-token-fail-missing-code",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.NULL).description("응답 데이터").optional()
+                                        )
                                         .build()
                         )
                 ));
@@ -179,5 +219,211 @@ public class KakaoControllerTest extends ControllerTestConfig {
                                 .build()
                 )
         ));
+    }
+
+    @Test
+    @DisplayName("카카오 톡캘린더 이벤트 생성 시 필수값만으로도 동작한다.")
+    public void createCalendarEvent_withRequiredFieldsOnly() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+        String accessToken = "sample_access_token";
+
+        String kakaoCalendarEventId = "sample_kakao_calendar_event_id";
+        KakaoCalendarEventResponse response = new KakaoCalendarEventResponse(kakaoCalendarEventId);
+
+        Mockito.when(kakaoService.createCalendarEvent(any(CreateKakaoCalendarEventRequest.class))).thenReturn(response);
+
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                accessToken,
+                eventId,
+                null, null, null, null, null
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                        .content(requestContent)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.is_success").value(true))
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.message").value("카카오 캘린더 일정 생성에 성공했습니다."))
+                .andExpect(jsonPath("$.payload.event_id").value(kakaoCalendarEventId));
+    }
+
+    @Test
+    @DisplayName("[FAILED] 톡캘린더 일정 생성 - 액세스 토큰 누락")
+    public void createCalendarEvent_Fail_MissingAccessToken() throws Exception {
+        // given
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                null,
+                UUID.randomUUID(),
+                "Description",
+                null, null, null, null
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.is_success").value(false))
+                .andExpect(jsonPath("$.code").value("E_BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("액세스 토큰은 필수입니다."))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/create-calendar-event-fail-missing-token",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.NULL).description("응답 데이터").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[FAILED] 톡캘린더 일정 생성 - 확정 정보를 찾을 수 없음")
+    public void createCalendarEvent_Fail_ConfirmationNotFound() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+        String accessToken = "sample_access_token";
+
+        Mockito.when(kakaoService.createCalendarEvent(any(CreateKakaoCalendarEventRequest.class)))
+                .thenThrow(new CustomException(EventErrorStatus._NOT_FOUND_EVENT_CONFIRMATION));
+
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                accessToken,
+                eventId,
+                null, null, null, null, null
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.is_success").value(false))
+                .andExpect(jsonPath("$.code").value("EVENT-008"))
+                .andExpect(jsonPath("$.message").value("확정된 이벤트 정보를 찾을 수 없습니다."))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/create-calendar-event-fail-confirmation-not-found",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.NULL).description("응답 데이터").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[FAILED] 톡캘린더 일정 생성 - 이벤트를 찾을 수 없음")
+    public void createCalendarEvent_Fail_EventNotFound() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+        String accessToken = "sample_access_token";
+
+        Mockito.when(kakaoService.createCalendarEvent(any(CreateKakaoCalendarEventRequest.class)))
+                .thenThrow(new CustomException(EventErrorStatus._NOT_FOUND_EVENT));
+
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                accessToken,
+                eventId,
+                null, null, null, null, null
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.is_success").value(false))
+                .andExpect(jsonPath("$.code").value("EVENT-001"))
+                .andExpect(jsonPath("$.message").value("이벤트를 찾을 수 없습니다."))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/create-calendar-event-fail-event-not-found",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.NULL).description("응답 데이터").optional()
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[FAILED] 유효하지 않은 확정 요청을 보낸다.")
+    public void createCalendarEvent_Fail_InvalidRequest() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+
+        Mockito.when(kakaoService.createCalendarEvent(any(CreateKakaoCalendarEventRequest.class)))
+                .thenThrow(new CustomException(EventErrorStatus._INVALID_CONFIRMATION_REQUEST));
+
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                "sample_access_token",
+                eventId,
+                null, null, null, null, null
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                        .content(requestContent)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.is_success").value(false))
+                .andExpect(jsonPath("$.code").value("EVENT-006"))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 확정 요청입니다."))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/create-calendar-event-fail-invalid-request",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.NULL).description("응답 데이터").optional()
+                                        )
+                                        .build()
+                        )
+                ));
     }
 }

--- a/src/test/java/side/onetime/kakao/KakaoControllerTest.java
+++ b/src/test/java/side/onetime/kakao/KakaoControllerTest.java
@@ -1,0 +1,183 @@
+package side.onetime.kakao;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+import side.onetime.configuration.ControllerTestConfig;
+import side.onetime.controller.KakaoController;
+import side.onetime.dto.kakao.api.KakaoCalendarEventResponse;
+import side.onetime.dto.kakao.request.CreateKakaoCalendarEventRequest;
+import side.onetime.dto.kakao.request.KakaoTokenRequest;
+import side.onetime.dto.kakao.response.KakaoTokenResponse;
+import side.onetime.service.KakaoService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(KakaoController.class)
+public class KakaoControllerTest extends ControllerTestConfig {
+
+    @MockBean
+    private KakaoService kakaoService;
+
+    @Test
+    @DisplayName("카카오 인증 페이지 URL을 조회 및 리다이렉트한다.")
+    public void getAuthorizeUrl() throws Exception {
+        // given
+        String authorizeUrl = "https://kauth.kakao.com/oauth/authorize?client_id=...&redirect_uri=...&response_type=code";
+        Mockito.when(kakaoService.getAuthorizeUrl()).thenReturn(authorizeUrl);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/kakao/authorize-url")
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isFound())
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/get-authorize-url",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .description("카카오 인증 페이지 URL을 조회 및 리다이렉트한다.")
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("카카오 토큰을 발급한다.")
+    public void getKakaoToken() throws Exception {
+        // given
+        String code = "sample_auth_code";
+        String accessToken = "sample_access_token";
+        KakaoTokenResponse response = new KakaoTokenResponse(accessToken);
+
+        Mockito.when(kakaoService.getKakaoToken(anyString())).thenReturn(response);
+
+        KakaoTokenRequest request = new KakaoTokenRequest(code);
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/token")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.is_success").value(true))
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("카카오 토큰 발급에 성공했습니다."))
+                .andExpect(jsonPath("$.payload.access_token").value(accessToken))
+                .andDo(MockMvcRestDocumentationWrapper.document("kakao/get-token",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("Kakao API")
+                                        .description("인가 코드를 사용하여 카카오 토큰을 발급받습니다.")
+                                        .requestFields(
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("카카오 인가 코드")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("payload").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                                fieldWithPath("payload.access_token").type(JsonFieldType.STRING).description("액세스 토큰")
+                                        )
+                                        .requestSchema(Schema.schema("KakaoTokenRequestSchema"))
+                                        .responseSchema(Schema.schema("KakaoTokenResponseSchema"))
+                                        .build()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("카카오 톡캘린더 이벤트를 생성한다.")
+    public void createCalendarEvent() throws Exception {
+        // given
+        UUID eventId = UUID.randomUUID();
+        String accessToken = "sample_access_token";
+
+        String kakaoCalendarEventId = "sample_kakao_calendar_event_id";
+        KakaoCalendarEventResponse response = new KakaoCalendarEventResponse(kakaoCalendarEventId);
+
+        Mockito.when(kakaoService.createCalendarEvent(any(CreateKakaoCalendarEventRequest.class))).thenReturn(response);
+
+        CreateKakaoCalendarEventRequest request = new CreateKakaoCalendarEventRequest(
+                accessToken,
+                eventId,
+                "OneTime에 의해 추가된 일정입니다.",
+                List.of(30, 1440),
+                "LAVENDER",
+                "FREQ=WEEKLY",
+                "Asia/Seoul"
+        );
+        String requestContent = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/kakao/calendar/confirmation")
+                .content(requestContent)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.is_success").value(true))
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.message").value("카카오 캘린더 일정 생성에 성공했습니다."))
+                .andExpect(jsonPath("$.payload.event_id").value(kakaoCalendarEventId));
+
+        // docs
+        resultActions.andDo(MockMvcRestDocumentationWrapper.document("kakao/create-calendar-event",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                ResourceDocumentation.resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("Kakao API")
+                                .description("확정 정보를 기반으로 카카오 톡캘린더 일정을 생성합니다.")
+                                .requestFields(
+                                        fieldWithPath("access_token").type(JsonFieldType.STRING).description("카카오 액세스 토큰"),
+                                        fieldWithPath("event_id").type(JsonFieldType.STRING).description("이벤트 ID (UUID)"),
+                                        fieldWithPath("description").type(JsonFieldType.STRING).description("일정 설명 (기본값 있음)").optional(),
+                                        fieldWithPath("reminders").type(JsonFieldType.ARRAY).description("리마인더 설정 (분 단위 리스트, 기본값 있음)").optional(),
+                                        fieldWithPath("color").type(JsonFieldType.STRING).description("색상 텍스트 (기본값 있음)").optional(),
+                                        fieldWithPath("rrule").type(JsonFieldType.STRING).description("반복 설정 (RRULE, 기본값 있음)").optional(),
+                                        fieldWithPath("time_zone").type(JsonFieldType.STRING).description("타임존 (기본값: Asia/Seoul)").optional()
+                                )
+                                .responseFields(
+                                        fieldWithPath("is_success").type(JsonFieldType.BOOLEAN).description("성공 여부"),
+                                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("payload").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                        fieldWithPath("payload.event_id").type(JsonFieldType.STRING).description("생성된 카카오 이벤트 ID")
+                                )
+                                .requestSchema(Schema.schema("CreateKakaoCalendarEventRequestSchema"))
+                                .responseSchema(Schema.schema("KakaoCalendarEventResponseSchema"))
+                                .build()
+                )
+        ));
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -79,3 +79,5 @@ app:
   sync:
     target-url: "http://localhost:8089"
     api-key: test-sync-api-key
+  kakao:
+    calendar-redirect-uri: "http://localhost:3000/kakao/callback"


### PR DESCRIPTION
## 🎯 Summary
> 이 PR의 목적을 한 줄로 요약해주세요
- 톡캘린더에 확정 이벤트 일정을 등록하는 기능을 구현했습니다.

---

## 🔴 AS-IS
> 기존 상태 또는 문제점
- 프론트에서 톡캘린더 API에 직접 접근하여 동작
- 프론트에서 이벤트의 데이터를 계산하는 로직 (startAt, endAt) 및 환경변수 관리 문제


## 🟢 TO-BE
> 변경 후 상태 또는 개선점
- 백엔드에서 환경변수 관리 및 프론트에서 백엔드(서버)를 거쳐 톡캘린더로 접근
- 프론트에서 시간 및 데이터 가공 처리를 백에서 처리, 프론트에서 전송하는 데이터 크기 감소
  - 톡캘린더 일정 등록 시 eventId와 accessToken만 필수, 이외는 선택 (디폴트 값은 서버에서 설정되어 있음)

---

## 💬 참고사항
> 리뷰어가 알아야 할 내용, 논의 포인트, 주의사항 등
- 카카오 로그인 시, 톡캘린더 전용 Redirect Uri 추가 및 Kakao Developers에 반영 완료
- 뭐가 문제인지 모르겠는데.. yml, SecurityConfig에서 코드 변경 사항이 이상하게 표기되고 있네요.. IDE에서는 문제가 없는데.. Kakao OAuth를 공통 yml에 옮기고, 톡캘린더 전용 리다이렉트 uri가 추가되었습니다~!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 OAuth 인증 연동 추가 — 인증 URL 제공 및 카카오 로그인 흐름 지원
  * 카카오 액세스 토큰 발급 지원
  * 카카오 톡캘린더에 일정 생성 기능 추가

* **Tests**
  * 카카오 인증, 토큰 발급 및 캘린더 일정 생성 엔드포인트에 대한 통합/문서화 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->