### PR TITLE
fix: (#356) 어드민 로그인 세션이 1시간 후 풀리는 버그 수정

### DIFF
--- a/src/main/java/side/onetime/global/filter/JwtFilter.java
+++ b/src/main/java/side/onetime/global/filter/JwtFilter.java
@@ -103,10 +103,19 @@ public class JwtFilter extends OncePerRequestFilter {
                 authenticateUser(reissued.accessToken());
                 filterChain.doFilter(request, response);
                 return;
-            } catch (Exception e) {
+            } catch (CustomException e) {
+                if (e.getErrorCode() == TokenErrorStatus._DUPLICATED_REQUEST) {
+                    // 동시 요청으로 인한 중복 재발급 - 다른 요청이 새 토큰을 이미 발급했으므로 쿠키 유지
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 log.warn("[Admin] 토큰 재발급 실패 - 사유: {}", e.getMessage());
                 CookieUtil.clearAdminTokenCookies(request, response);
                 response.sendRedirect("/admin/login");
+                return;
+            } catch (Exception e) {
+                log.error("[Admin] 토큰 재발급 중 시스템 오류", e);
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 return;
             }
         }

--- a/src/main/java/side/onetime/global/filter/JwtFilter.java
+++ b/src/main/java/side/onetime/global/filter/JwtFilter.java
@@ -20,6 +20,7 @@ import side.onetime.auth.service.CustomUserDetailsService;
 import side.onetime.dto.token.request.ReissueTokenRequest;
 import side.onetime.dto.token.response.ReissueTokenResponse;
 import side.onetime.exception.CustomException;
+import side.onetime.exception.status.TokenErrorStatus;
 import side.onetime.service.TokenService;
 import side.onetime.util.ClientInfoExtractor;
 import side.onetime.util.CookieUtil;
@@ -54,63 +55,84 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        String token = null;
-        String refreshToken = null;
-        boolean isAdminRequest = false;
-
-        // 1. API 요청의 Authorization 헤더에서 토큰 추출
-        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            token = jwtUtil.getTokenFromHeader(authorizationHeader);
-        }
-
-        // 2. 어드민 요청(페이지 + API)의 쿠키에서 토큰 추출
         String requestUri = request.getRequestURI();
-        if (token == null && (requestUri.startsWith("/admin") || requestUri.startsWith("/api/v1/admin"))) {
-            var adminAccessToken = CookieUtil.getAdminAccessToken(request);
-            if (adminAccessToken.isPresent()) {
-                token = adminAccessToken.get();
-                isAdminRequest = true;
-                refreshToken = CookieUtil.getAdminRefreshToken(request).orElse(null);
-            }
+        if (requestUri.startsWith("/admin") || requestUri.startsWith("/api/v1/admin")) {
+            handleAdminRequest(request, response, filterChain);
+        } else {
+            handleApiRequest(request, response, filterChain);
         }
+    }
 
-        if (token == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+    /**
+     * 어드민 요청: 쿠키 기반 인증. 액세스 토큰 만료 시 리프레시 토큰으로 자동 재발급.
+     */
+    private void handleAdminRequest(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
 
-        try {
-            jwtUtil.validateToken(token);
-            authenticateUser(token);
-            filterChain.doFilter(request, response);
+        String accessToken = CookieUtil.getAdminAccessToken(request).orElse(null);
+        String refreshToken = CookieUtil.getAdminRefreshToken(request).orElse(null);
 
-        } catch (CustomException e) {
-            // 어드민 요청이고 리프레시 토큰이 있으면 자동 재발급 시도
-            if (isAdminRequest && refreshToken != null) {
-                try {
-                    String userIp = clientInfoExtractor.extractClientIp(request);
-                    String userAgent = clientInfoExtractor.extractUserAgent(request);
-                    ReissueTokenResponse reissued = tokenService.reissueToken(
-                            new ReissueTokenRequest(refreshToken), userIp, userAgent
-                    );
-
-                    // 새 토큰으로 쿠키 갱신
-                    CookieUtil.setAdminTokenCookies(request, response, reissued.accessToken(), reissued.refreshToken());
-
-                    // 새 액세스 토큰으로 인증
-                    authenticateUser(reissued.accessToken());
-                    filterChain.doFilter(request, response);
-                    return;
-
-                } catch (Exception reissueEx) {
-                    log.warn("[Admin] 토큰 재발급 실패 - 사유: {}", reissueEx.getMessage());
-                    // 재발급 실패 시 로그인 페이지로 리다이렉트
+        // 액세스 토큰이 유효하면 바로 통과
+        if (accessToken != null) {
+            try {
+                jwtUtil.validateToken(accessToken);
+                authenticateUser(accessToken);
+                filterChain.doFilter(request, response);
+                return;
+            } catch (CustomException e) {
+                // 만료된 경우에만 리프레시 토큰으로 재발급 시도, 그 외(서명 위조, 변조 등)는 즉시 거부
+                if (e.getErrorCode() != TokenErrorStatus._TOKEN_EXPIRED) {
+                    log.warn("[Admin] 액세스 토큰 검증 실패 (만료 외) - 사유: {}", e.getMessage());
+                    CookieUtil.clearAdminTokenCookies(request, response);
                     response.sendRedirect("/admin/login");
                     return;
                 }
             }
+        }
 
+        // 리프레시 토큰으로 재발급 시도
+        if (refreshToken != null) {
+            try {
+                String userIp = clientInfoExtractor.extractClientIp(request);
+                String userAgent = clientInfoExtractor.extractUserAgent(request);
+                ReissueTokenResponse reissued = tokenService.reissueToken(
+                        new ReissueTokenRequest(refreshToken), userIp, userAgent
+                );
+
+                CookieUtil.setAdminTokenCookies(request, response, reissued.accessToken(), reissued.refreshToken());
+                authenticateUser(reissued.accessToken());
+                filterChain.doFilter(request, response);
+                return;
+            } catch (Exception e) {
+                log.warn("[Admin] 토큰 재발급 실패 - 사유: {}", e.getMessage());
+                CookieUtil.clearAdminTokenCookies(request, response);
+                response.sendRedirect("/admin/login");
+                return;
+            }
+        }
+
+        // 토큰 없음 → Spring Security가 처리 (로그인 페이지로 리다이렉트)
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 일반 API 요청: Authorization 헤더 기반 인증.
+     */
+    private void handleApiRequest(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = jwtUtil.getTokenFromHeader(authorizationHeader);
+        try {
+            jwtUtil.validateToken(token);
+            authenticateUser(token);
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
             log.error("JWT 필터 예외 발생 - 요청 URI: {}, 메서드: {}", request.getRequestURI(), request.getMethod());
             writeErrorResponse(response, e);
         }


### PR DESCRIPTION
## Summary

- 어드민 로그인 후 1시간이 지나면 세션이 풀리는 버그를 수정합니다.

## 문제점

`JwtFilter`에서 어드민 인증 시, Access Token **쿠키가 존재할 때만** Refresh Token을 확인하는 구조였습니다.

```java
// 기존 코드
if (adminAccessToken.isPresent()) {  // 쿠키 없으면 여기서 false
    token = adminAccessToken.get();
    isAdminRequest = true;
    refreshToken = ...;  // Refresh Token 확인 기회 없음
}
```

- Access Token 쿠키 Max-Age: **1시간** → 만료 시 브라우저가 쿠키 자체를 삭제
- Refresh Token 쿠키 Max-Age: **14일** → 아직 살아있음
- 1시간 후 요청 시: Access Token 쿠키 없음 → Refresh Token 확인 안 함 → 인증 실패 → 로그인 페이지로 redirect

프로덕션 로그에서도 `[Admin] 토큰 재발급 실패` 로그가 0건이고, `❌ 인증되지 않은 접근 - /admin/dashboard` 로그만 반복 발생하여 자동 리프레시가 한 번도 실행되지 않았음을 확인했습니다.

## 해결 방식

`JwtFilter`를 어드민/API 요청 핸들러로 분리하고, Access Token 쿠키 유무와 관계없이 Refresh Token으로 재발급을 시도하도록 수정했습니다.

```
handleAdminRequest()
├─ Access Token 유효 → 통과
├─ Access Token 만료 + Refresh Token 있음 → 재발급 후 통과
├─ Access Token 위조/변조 → 즉시 거부 (쿠키 삭제 + 로그인 redirect)
└─ 토큰 없음 → Spring Security 처리

handleApiRequest()
├─ Bearer 헤더 없음 → 통과
└─ 있으면 검증 → 성공/실패
```

추가 개선:
- 만료 외 토큰 오류(서명 위조 등)는 리프레시 시도 없이 즉시 거부
- 재발급 실패 시 무효 쿠키를 삭제하여 반복 실패 방지

## Test plan

- [x] 어드민 로그인 후 1시간 경과 뒤 대시보드 접근 시 자동 재발급 확인
- [x] 14일 경과 후 Refresh Token 만료 시 로그인 페이지로 정상 redirect 확인
- [x] 위조된 Access Token 쿠키 전송 시 즉시 거부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **수정 사항**
  * 관리자 요청과 일반 API 요청의 인증 흐름을 분리하여 처리 안정성 향상
  * 관리자 토큰은 만료 시에만 자동 갱신 시도, 갱신 실패 시 관리자 로그인으로 리다이렉트
  * 일반 API 요청은 인증 오류 시 즉시 오류 응답 처리(자동 갱신 미시도)
  * 관리자 인증 검증 로직 최적화로 로그인/세션 처리 신뢰성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->