### PR TITLE
refactor: 이미지 저장소를 추상화하고 로컬 디스크 구현체를 추가한다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ OneTime is a Spring Boot-based backend API for a collaborative event scheduling 
 - **Framework**: Spring Boot 3.3.2
 - **Database**: MySQL 8.0 with Spring Data JPA, QueryDSL 5.0
 - **Security**: Spring Security, OAuth2 (Google, Kakao, Naver), JWT (JJWT 0.12.2)
-- **Cloud**: AWS S3 (Spring Cloud AWS 3.1.1), SQS (AWS SDK 2.25.30), CodeDeploy
+- **Cloud**: 이미지 저장소는 `FileStorage` 추상화 (S3 / 서버 로컬 디스크, `storage.type` 으로 선택), SQS (AWS SDK 2.25.30), CodeDeploy
 - **Email**: AWS SQS (비동기 큐) → Batch → AWS SES (발송). 상세: `docs/features/26-01-26-admin-statistics.md`
 - **Documentation**: Spring REST Docs 3.0.0, SpringDoc OpenAPI 2.1.0
 - **Build**: Gradle 8.x
@@ -60,8 +60,9 @@ src/main/java/side/onetime/
 │   ├── filter/          # JwtFilter
 │   └── common/          # ApiResponse<T>, status codes, BaseEntity
 ├── exception/           # CustomException, GlobalExceptionHandler
-├── infra/               # External integrations (Everytime client)
-└── util/                # Utility classes (JwtUtil, S3Util, etc.)
+├── infra/               # External integrations (Everytime client, storage)
+│   └── storage/         # FileStorage 추상화 (S3FileStorage / LocalFileStorage)
+└── util/                # Utility classes (JwtUtil, QrUtil, etc.)
 ```
 
 ## Code Conventions

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,11 +154,20 @@ flowchart TB
 | MyBatis | 도메인 객체 간 관계 매핑 불편, 엔티티 상태 관리 부재 |
 | Spring JDBC 단독 | ORM 장점 포기, 보일러플레이트 증가 |
 
-### AWS S3 + ZXing (QR 코드)
+### 이미지 저장소 (FileStorage) + ZXing (QR 코드)
 
-**왜 S3인가:** 이벤트별 QR 코드 이미지와 관리자 배너 이미지를 저장한다. 정적 파일 서빙에 최적화되어 있고, CloudFront 연동 시 글로벌 배포가 가능하다.
+**왜 추상화인가:** 이벤트별 QR 코드 이미지와 관리자 배너 이미지의 저장소를 `side.onetime.infra.storage.FileStorage` 뒤로 숨긴다. `storage.type` 프로퍼티로 구현체를 고른다.
 
-**왜 ZXing인가:** Java 네이티브 QR 코드 생성 라이브러리 중 가장 성숙하고, 별도 외부 서비스 없이 서버에서 직접 QR을 생성하여 S3에 업로드한다.
+| `storage.type` | 구현체 | 저장 위치 | 서빙 |
+|----------------|--------|-----------|------|
+| `s3` (기본값) | `S3FileStorage` | AWS S3 버킷 | `https://{bucket}.s3.{region}.amazonaws.com/{key}` |
+| `local` | `LocalFileStorage` | 서버 디스크 (`storage.local.root`) | nginx 정적 서빙 (`storage.local.public-base-url`) |
+
+`local` 모드는 AWS 이탈을 위해 추가했다. 실데이터가 7MB 수준이라 오브젝트 스토리지를 유지할 이유가 약하고, 외부 벤더 의존을 하나 줄인다. 단 파일이 서버와 운명을 같이하므로 백업에 포함해야 한다.
+
+관련 환경 변수: `STORAGE_TYPE`, `FILE_STORAGE_PATH`, `FILE_PUBLIC_BASE_URL`
+
+**왜 ZXing인가:** Java 네이티브 QR 코드 생성 라이브러리 중 가장 성숙하고, 별도 외부 서비스 없이 서버에서 직접 QR을 생성하여 저장소에 업로드한다.
 
 | 탈락 후보 | 이유 |
 |-----------|------|
@@ -551,7 +560,7 @@ flowchart LR
 | Spring Data JPA | Boot 관리 | DB 접근 |
 | QueryDSL | 5.0.0 (Jakarta) | 동적 쿼리 |
 | JJWT | 0.12.2 | JWT 생성/검증 |
-| Spring Cloud AWS | 3.1.1 | S3, 인프라 |
+| Spring Cloud AWS | 3.1.1 | S3(`storage.type=s3`), 인프라 |
 | Spring Cloud OpenFeign | 4.1.4 | HTTP 클라이언트 |
 | SpringDoc OpenAPI | 2.1.0 | Swagger UI |
 | Spring REST Docs | 3.0.0 | API 문서 생성 |

--- a/src/main/java/side/onetime/global/config/S3Config.java
+++ b/src/main/java/side/onetime/global/config/S3Config.java
@@ -1,6 +1,7 @@
 package side.onetime.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -9,6 +10,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3", matchIfMissing = true)
 public class S3Config {
 
     @Value("${spring.cloud.aws.credentials.access-key}")

--- a/src/main/java/side/onetime/infra/storage/FileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/FileStorage.java
@@ -1,0 +1,42 @@
+package side.onetime.infra.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * 이미지 저장소 추상화.
+ *
+ * 구현체는 {@code storage.type} 프로퍼티로 선택됩니다.
+ * <ul>
+ *     <li>{@code s3}    - AWS S3 ({@link S3FileStorage}, 기본값)</li>
+ *     <li>{@code local} - 서버 로컬 디스크 ({@link LocalFileStorage})</li>
+ * </ul>
+ */
+public interface FileStorage {
+
+    /**
+     * 이미지를 업로드하고 저장소 내 고유 키를 반환합니다.
+     *
+     * @param directoryName 저장할 디렉토리명 (예: {@code qr}, {@code banner/3})
+     * @param image         업로드할 이미지 파일
+     * @return 저장소에 기록된 키 (퍼블릭 URL 아님)
+     * @throws IOException 업로드 중 오류 발생 시
+     */
+    String uploadImage(String directoryName, MultipartFile image) throws IOException;
+
+    /**
+     * 키에 해당하는 파일의 퍼블릭 URL을 반환합니다.
+     */
+    String getPublicUrl(String key);
+
+    /**
+     * 퍼블릭 URL에서 저장소 키를 추출합니다.
+     */
+    String extractKey(String publicUrl);
+
+    /**
+     * 키에 해당하는 파일을 삭제합니다.
+     */
+    void deleteFile(String key);
+}

--- a/src/main/java/side/onetime/infra/storage/FileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/FileStorage.java
@@ -3,6 +3,8 @@ package side.onetime.infra.storage;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * 이미지 저장소 추상화.
@@ -14,6 +16,35 @@ import java.io.IOException;
  * </ul>
  */
 public interface FileStorage {
+
+    Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/png", "image/jpeg", "image/webp", "image/gif");
+
+    Set<String> ALLOWED_EXTENSIONS = Set.of("png", "jpg", "jpeg", "webp", "gif");
+
+    /**
+     * 업로드 이미지의 형식을 검증합니다. 구현체는 저장 전에 반드시 호출해야 합니다.
+     *
+     * 로컬 저장소는 파일을 API와 같은 오리진(api.onetime.run)에서 서빙하므로,
+     * svg/html 같은 스크립트 해석 가능한 형식이 올라가면 저장형 XSS가 됩니다.
+     * nginx 쪽에서도 해당 확장자를 차단하지만, 애초에 디스크에 남기지 않습니다.
+     *
+     * 확장자가 없는 경우는 허용합니다. QR 이미지의 원본 파일명이 {@code "qr"} 입니다.
+     */
+    static void validateImage(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("허용되지 않은 이미지 형식입니다: " + contentType);
+        }
+
+        String filename = image.getOriginalFilename();
+        int dot = filename == null ? -1 : filename.lastIndexOf('.');
+        if (dot >= 0) {
+            String extension = filename.substring(dot + 1).toLowerCase(Locale.ROOT);
+            if (!ALLOWED_EXTENSIONS.contains(extension)) {
+                throw new IllegalArgumentException("허용되지 않은 이미지 확장자입니다: " + extension);
+            }
+        }
+    }
 
     /**
      * 이미지를 업로드하고 저장소 내 고유 키를 반환합니다.

--- a/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -29,6 +28,11 @@ public class LocalFileStorage implements FileStorage {
             @Value("${storage.local.root}") String root,
             @Value("${storage.local.public-base-url}") String publicBaseUrl
     ) {
+        // 비어 있으면 getPublicUrl 이 루트 상대 경로를 뱉어 QR/배너 링크가 조용히 깨진다. 기동 시점에 막는다.
+        if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+            throw new IllegalStateException(
+                    "storage.type=local 인 경우 storage.local.public-base-url(FILE_PUBLIC_BASE_URL)이 필요합니다.");
+        }
         this.root = Path.of(root).toAbsolutePath().normalize();
         this.publicBaseUrl = publicBaseUrl.endsWith("/")
                 ? publicBaseUrl.substring(0, publicBaseUrl.length() - 1)
@@ -56,19 +60,25 @@ public class LocalFileStorage implements FileStorage {
      * 퍼블릭 URL에서 키를 추출합니다.
      *
      * 마이그레이션 이전에 저장된 S3 형식 URL도 처리할 수 있도록,
-     * 베이스 URL의 경로 접두사가 있으면 떼어내고 없으면 경로 전체를 키로 봅니다.
+     * 베이스 URL 접두사가 있으면 떼어내고 없으면 호스트 뒤 경로 전체를 키로 봅니다.
+     *
+     * URL 파서를 쓰지 않고 문자열로 자릅니다. 업로드 원본 파일명에 공백이나 한글이
+     * 그대로 들어가는데({@code "스크린샷 2025-09-12.png"}), 그런 URL은 URI 파서가 거부합니다.
      */
     @Override
     public String extractKey(String publicUrl) {
-        String path = URI.create(publicUrl).getPath();
-        if (path == null || path.length() <= 1) {
+        if (publicUrl == null || publicUrl.isBlank()) {
             throw new IllegalArgumentException("유효하지 않은 파일 URL : " + publicUrl);
         }
-        String basePath = URI.create(publicBaseUrl).getPath();
-        if (!basePath.isEmpty() && path.startsWith(basePath + "/")) {
-            path = path.substring(basePath.length() + 1);
+        if (publicUrl.startsWith(publicBaseUrl + "/")) {
+            return publicUrl.substring(publicBaseUrl.length() + 1);
         }
-        return path.startsWith("/") ? path.substring(1) : path;
+        int schemeEnd = publicUrl.indexOf("://");
+        int pathStart = publicUrl.indexOf('/', schemeEnd < 0 ? 0 : schemeEnd + 3);
+        if (pathStart < 0 || pathStart == publicUrl.length() - 1) {
+            throw new IllegalArgumentException("유효하지 않은 파일 URL : " + publicUrl);
+        }
+        return publicUrl.substring(pathStart + 1);
     }
 
     @Override

--- a/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
@@ -41,6 +41,8 @@ public class LocalFileStorage implements FileStorage {
 
     @Override
     public String uploadImage(String directoryName, MultipartFile image) throws IOException {
+        FileStorage.validateImage(image);
+
         String key = directoryName + "/" + UUID.randomUUID() + "_" + sanitize(image.getOriginalFilename());
         Path target = resolve(key);
 
@@ -91,11 +93,18 @@ public class LocalFileStorage implements FileStorage {
     }
 
     /**
-     * 키를 루트 하위 실제 경로로 변환합니다. 루트를 벗어나면 거부합니다. (경로 탈출 방지)
+     * 키를 루트 하위 실제 경로로 변환합니다. 루트를 벗어나거나 루트 자신을 가리키면 거부합니다.
+     *
+     * 모든 파일 조작이 이 메서드를 거치므로, 경로 검증은 여기 한 곳에서만 합니다.
+     * 루트 자신을 막는 이유: 빈 키나 {@code "x/.."} 처럼 상쇄되는 키가 루트로 정규화되면
+     * {@code deleteFile} 이 저장소 디렉토리 자체를 지우려 든다.
      */
     private Path resolve(String key) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("허용되지 않은 파일 경로: " + key);
+        }
         Path target = root.resolve(key).normalize();
-        if (!target.startsWith(root)) {
+        if (!target.startsWith(root) || target.equals(root)) {
             throw new IllegalArgumentException("허용되지 않은 파일 경로: " + key);
         }
         return target;

--- a/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/LocalFileStorage.java
@@ -1,0 +1,103 @@
+package side.onetime.infra.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+/**
+ * 서버 로컬 디스크 기반 저장소 구현체.
+ *
+ * 파일은 {@code storage.local.root} 아래에 S3와 동일한 키 구조로 저장되고,
+ * nginx가 {@code storage.local.public-base-url} 경로로 정적 서빙합니다.
+ */
+@Component
+@ConditionalOnProperty(name = "storage.type", havingValue = "local")
+public class LocalFileStorage implements FileStorage {
+
+    private final Path root;
+    private final String publicBaseUrl;
+
+    public LocalFileStorage(
+            @Value("${storage.local.root}") String root,
+            @Value("${storage.local.public-base-url}") String publicBaseUrl
+    ) {
+        this.root = Path.of(root).toAbsolutePath().normalize();
+        this.publicBaseUrl = publicBaseUrl.endsWith("/")
+                ? publicBaseUrl.substring(0, publicBaseUrl.length() - 1)
+                : publicBaseUrl;
+    }
+
+    @Override
+    public String uploadImage(String directoryName, MultipartFile image) throws IOException {
+        String key = directoryName + "/" + UUID.randomUUID() + "_" + sanitize(image.getOriginalFilename());
+        Path target = resolve(key);
+
+        Files.createDirectories(target.getParent());
+        try (var in = image.getInputStream()) {
+            Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return key;
+    }
+
+    @Override
+    public String getPublicUrl(String key) {
+        return publicBaseUrl + "/" + key;
+    }
+
+    /**
+     * 퍼블릭 URL에서 키를 추출합니다.
+     *
+     * 마이그레이션 이전에 저장된 S3 형식 URL도 처리할 수 있도록,
+     * 베이스 URL의 경로 접두사가 있으면 떼어내고 없으면 경로 전체를 키로 봅니다.
+     */
+    @Override
+    public String extractKey(String publicUrl) {
+        String path = URI.create(publicUrl).getPath();
+        if (path == null || path.length() <= 1) {
+            throw new IllegalArgumentException("유효하지 않은 파일 URL : " + publicUrl);
+        }
+        String basePath = URI.create(publicBaseUrl).getPath();
+        if (!basePath.isEmpty() && path.startsWith(basePath + "/")) {
+            path = path.substring(basePath.length() + 1);
+        }
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    @Override
+    public void deleteFile(String key) {
+        try {
+            Files.deleteIfExists(resolve(key));
+        } catch (IOException e) {
+            throw new IllegalStateException("파일 삭제 실패: " + key, e);
+        }
+    }
+
+    /**
+     * 키를 루트 하위 실제 경로로 변환합니다. 루트를 벗어나면 거부합니다. (경로 탈출 방지)
+     */
+    private Path resolve(String key) {
+        Path target = root.resolve(key).normalize();
+        if (!target.startsWith(root)) {
+            throw new IllegalArgumentException("허용되지 않은 파일 경로: " + key);
+        }
+        return target;
+    }
+
+    /**
+     * 업로드 원본 파일명에서 경로 구분자를 제거합니다.
+     */
+    private String sanitize(String originalFilename) {
+        if (originalFilename == null || originalFilename.isBlank()) {
+            return "file";
+        }
+        return originalFilename.replaceAll("[/\\\\]", "_");
+    }
+}

--- a/src/main/java/side/onetime/infra/storage/S3FileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/S3FileStorage.java
@@ -1,7 +1,8 @@
-package side.onetime.util;
+package side.onetime.infra.storage;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -14,9 +15,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 
+/**
+ * AWS S3 기반 저장소 구현체. (기존 S3Util의 동작을 그대로 옮긴 것)
+ */
 @Component
 @RequiredArgsConstructor
-public class S3Util {
+@ConditionalOnProperty(name = "storage.type", havingValue = "s3", matchIfMissing = true)
+public class S3FileStorage implements FileStorage {
+
     private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.bucket}")
@@ -25,73 +31,45 @@ public class S3Util {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
-    /**
-     * S3에 이미지 업로드 메서드.
-     * 주어진 MultipartFile 이미지를 S3에 업로드하고 고유한 파일 이름을 반환합니다.
-     *
-     * @param directoryName 업로드할 디렉토리명
-     * @param image          업로드할 이미지 파일
-     * @return S3에 저장된 파일 이름
-     * @throws IOException 파일 업로드 중 오류 발생 시
-     */
+    @Override
     public String uploadImage(String directoryName, MultipartFile image) throws IOException {
-        // 고유한 파일 이름 생성
         String fileName = directoryName + "/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
 
-        // S3에 파일 업로드 요청 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(fileName)
                 .contentType(image.getContentType())
                 .build();
 
-        // S3에 파일 업로드
         s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(image.getInputStream(), image.getSize()));
 
         return fileName;
     }
 
-    /**
-     * S3에 저장된 파일의 퍼블릭 URL 반환 메서드.
-     * 주어진 파일 이름에 해당하는 S3 파일의 퍼블릭 URL을 반환합니다.
-     *
-     * @param fileName S3에 저장된 파일 이름
-     * @return 파일의 퍼블릭 URL
-     */
-    public String getPublicUrl(String fileName) {
-        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+    @Override
+    public String getPublicUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
     }
 
-    /**
-     * S3 퍼블릭 URL에서 파일 이름을 추출하는 메서드.
-     *
-     * @param fileUrl S3 퍼블릭 URL
-     * @return S3에 저장된 파일 이름
-     */
-    public static String extractKey(String fileUrl) {
+    @Override
+    public String extractKey(String publicUrl) {
         try {
-            URL url = new URL(fileUrl);
+            URL url = new URL(publicUrl);
             String path = url.getPath();
             if (path == null || path.length() <= 1) {
-                throw new IllegalArgumentException("유효하지 않은 S3 URL : " + fileUrl);
+                throw new IllegalArgumentException("유효하지 않은 S3 URL : " + publicUrl);
             }
             return path.startsWith("/") ? path.substring(1) : path;
         } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("잘못된 URL 형식: " + fileUrl);
+            throw new IllegalArgumentException("잘못된 URL 형식: " + publicUrl);
         }
     }
 
-    /**
-     * S3에서 파일 삭제 메서드.
-     * 주어진 파일 이름에 해당하는 S3 파일을 삭제합니다.
-     *
-     * @param fileName S3에 저장된 파일 이름
-     */
-    public void deleteFile(String fileName) {
-        // 파일 삭제
+    @Override
+    public void deleteFile(String key) {
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                 .bucket(bucket)
-                .key(fileName)
+                .key(key)
                 .build();
 
         s3Client.deleteObject(deleteRequest);

--- a/src/main/java/side/onetime/infra/storage/S3FileStorage.java
+++ b/src/main/java/side/onetime/infra/storage/S3FileStorage.java
@@ -33,6 +33,8 @@ public class S3FileStorage implements FileStorage {
 
     @Override
     public String uploadImage(String directoryName, MultipartFile image) throws IOException {
+        FileStorage.validateImage(image);
+
         String fileName = directoryName + "/" + UUID.randomUUID() + "_" + image.getOriginalFilename();
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()

--- a/src/main/java/side/onetime/service/BannerService.java
+++ b/src/main/java/side/onetime/service/BannerService.java
@@ -26,7 +26,7 @@ import side.onetime.repository.AdminRepository;
 import side.onetime.repository.BannerRepository;
 import side.onetime.repository.BannerStagingRepository;
 import side.onetime.util.AdminAuthorizationUtil;
-import side.onetime.util.S3Util;
+import side.onetime.infra.storage.FileStorage;
 
 @Slf4j
 @Service
@@ -37,7 +37,7 @@ public class BannerService {
     private final AdminRepository adminRepository;
     private final BannerStagingRepository bannerStagingRepository;
     private final RestClient bannerClient;
-    private final S3Util s3Util;
+    private final FileStorage fileStorage;
 	private final BannerSyncProperties bannerSyncProperties;
 
     /**
@@ -321,8 +321,8 @@ public class BannerService {
      */
     private String uploadBannerImage(Long bannerId, MultipartFile imageFile) {
         try {
-            String imageFileName = s3Util.uploadImage("banner/" + bannerId, imageFile);
-            return s3Util.getPublicUrl(imageFileName);
+            String imageFileName = fileStorage.uploadImage("banner/" + bannerId, imageFile);
+            return fileStorage.getPublicUrl(imageFileName);
         } catch (Exception e) {
             throw new CustomException(AdminErrorStatus._FAILED_UPLOAD_BANNER_IMAGE);
         }
@@ -336,8 +336,8 @@ public class BannerService {
     private void deleteExistingBannerImage(String imageUrl) {
         if (imageUrl != null && !imageUrl.isBlank()) {
             try {
-                String imageFileKey = S3Util.extractKey(imageUrl);
-                s3Util.deleteFile(imageFileKey);
+                String imageFileKey = fileStorage.extractKey(imageUrl);
+                fileStorage.deleteFile(imageFileKey);
             } catch (Exception e) {
                 log.warn("❌ 배너 이미지 삭제 예외 발생 - 요청 IMAGE_URI: {}", imageUrl, e);
             }

--- a/src/main/java/side/onetime/service/EventCleanupScheduler.java
+++ b/src/main/java/side/onetime/service/EventCleanupScheduler.java
@@ -6,7 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import side.onetime.domain.Event;
 import side.onetime.repository.EventRepository;
-import side.onetime.util.S3Util;
+import side.onetime.infra.storage.FileStorage;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.List;
 public class EventCleanupScheduler {
 
     private final EventRepository eventRepository;
-    private final S3Util s3Util;
+    private final FileStorage fileStorage;
 
     /**
      * 오래된 이벤트 삭제 스케줄러.
@@ -39,7 +39,7 @@ public class EventCleanupScheduler {
 
             // QR 이미지 삭제
             if (qrFileName != null && !qrFileName.isEmpty()) {
-                s3Util.deleteFile(qrFileName);
+                fileStorage.deleteFile(qrFileName);
             }
             // 이벤트 삭제
             eventRepository.deleteEvent(event);

--- a/src/main/java/side/onetime/service/EventService.java
+++ b/src/main/java/side/onetime/service/EventService.java
@@ -14,6 +14,7 @@ import side.onetime.dto.event.request.CreateEventRequest;
 import side.onetime.dto.event.request.ModifyEventRequest;
 import side.onetime.dto.event.response.*;
 import side.onetime.dto.schedule.request.GetFilteredSchedulesRequest;
+import side.onetime.infra.storage.FileStorage;
 import side.onetime.exception.CustomException;
 import side.onetime.exception.status.EventErrorStatus;
 import side.onetime.exception.status.EventParticipationErrorStatus;
@@ -45,7 +46,7 @@ public class EventService {
 	private final EventConfirmationRepository eventConfirmationRepository;
 	private final ScheduleBatchRepository scheduleBatchRepository;
 	private final JwtUtil jwtUtil;
-	private final S3Util s3Util;
+	private final FileStorage fileStorage;
     private final QrUtil qrUtil;
 
     /**
@@ -232,7 +233,7 @@ public class EventService {
     private String generateAndUploadQrCode(UUID eventId) {
         try {
             MultipartFile qrCodeFile = qrUtil.getQrCodeFile(eventId);
-            return s3Util.uploadImage("qr", qrCodeFile);
+            return fileStorage.uploadImage("qr", qrCodeFile);
         } catch (Exception e) {
             throw new CustomException(EventErrorStatus._FAILED_GENERATE_QR_CODE);
         }
@@ -681,7 +682,7 @@ public class EventService {
         EventParticipation eventParticipation = verifyUserHasEventAccess(user, eventId);
 
         eventRepository.deleteEvent(eventParticipation.getEvent());
-        s3Util.deleteFile(eventParticipation.getEvent().getQrFileName()); // QR 이미지 삭제
+        fileStorage.deleteFile(eventParticipation.getEvent().getQrFileName()); // QR 이미지 삭제
     }
 
     /**
@@ -863,7 +864,7 @@ public class EventService {
             throw new CustomException(EventErrorStatus._NOT_FOUND_EVENT_QR_CODE);
         }
 
-        String qrCodeImgUrl = s3Util.getPublicUrl(event.getQrFileName());
+        String qrCodeImgUrl = fileStorage.getPublicUrl(event.getQrFileName());
         return GetEventQrCodeResponse.from(qrCodeImgUrl);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,14 +52,22 @@ spring:
   cloud:
     aws:
       credentials:
-        access-key: ${S3_ACCESS_KEY}
-        secret-key: ${S3_SECRET_KEY}
+        access-key: ${S3_ACCESS_KEY:}
+        secret-key: ${S3_SECRET_KEY:}
       region:
         static: ap-northeast-2
       s3:
-        bucket: ${S3_BUCKET_NAME}
+        bucket: ${S3_BUCKET_NAME:}
       sqs:
-        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL}
+        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL:}
+
+# 이미지 저장소. s3(기본) 또는 local 중 선택합니다.
+# local 은 파일을 서버 디스크에 두고 nginx 가 public-base-url 로 정적 서빙합니다.
+storage:
+  type: ${STORAGE_TYPE:s3}
+  local:
+    root: ${FILE_STORAGE_PATH:/srv/onetime/files}
+    public-base-url: ${FILE_PUBLIC_BASE_URL:}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,14 +52,14 @@ spring:
   cloud:
     aws:
       credentials:
-        access-key: ${S3_ACCESS_KEY:}
-        secret-key: ${S3_SECRET_KEY:}
+        access-key: ${S3_ACCESS_KEY}
+        secret-key: ${S3_SECRET_KEY}
       region:
         static: ap-northeast-2
       s3:
-        bucket: ${S3_BUCKET_NAME:}
+        bucket: ${S3_BUCKET_NAME}
       sqs:
-        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL:}
+        queue-url: ${AWS_SQS_EMAIL_QUEUE_URL}
 
 # 이미지 저장소. s3(기본) 또는 local 중 선택합니다.
 # local 은 파일을 서버 디스크에 두고 nginx 가 public-base-url 로 정적 서빙합니다.

--- a/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
+++ b/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
@@ -103,6 +103,48 @@ class LocalFileStorageTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> sut.deleteFile("../../etc/passwd"));
+        assertThrows(IllegalArgumentException.class,
+                () -> sut.deleteFile("/etc/passwd"));
+    }
+
+    @Test
+    @DisplayName("루트 자신을 가리키는 키는 거부한다 — 저장소 디렉토리가 지워지면 안 된다")
+    void rejectsKeyResolvingToRoot(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+
+        // 베이스 URL 뒤에 아무것도 없는 URL -> 빈 키
+        assertThrows(IllegalArgumentException.class,
+                () -> sut.deleteFile(sut.extractKey(BASE_URL + "/")));
+        // 상쇄되어 루트로 정규화되는 키
+        assertThrows(IllegalArgumentException.class,
+                () -> sut.deleteFile("qr/.."));
+
+        assertTrue(Files.exists(root), "저장소 루트가 살아있어야 한다");
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 형식은 업로드를 거부한다 — 같은 오리진에서 서빙되므로 저장형 XSS가 된다")
+    void rejectsNonImageUpload(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+
+        assertThrows(IllegalArgumentException.class, () -> sut.uploadImage("banner/1",
+                new MockMultipartFile("i", "x.svg", "image/svg+xml", "<svg onload=alert(1)>".getBytes())));
+        assertThrows(IllegalArgumentException.class, () -> sut.uploadImage("banner/1",
+                new MockMultipartFile("i", "x.html", "text/html", "<script>".getBytes())));
+        // content-type을 위조해도 확장자에서 걸린다
+        assertThrows(IllegalArgumentException.class, () -> sut.uploadImage("banner/1",
+                new MockMultipartFile("i", "x.html", "image/png", "<script>".getBytes())));
+    }
+
+    @Test
+    @DisplayName("확장자 없는 QR 이미지는 계속 허용한다 (원본 파일명이 \"qr\")")
+    void allowsExtensionlessQrImage(@TempDir Path root) throws IOException {
+        LocalFileStorage sut = storage(root);
+
+        String key = sut.uploadImage("qr",
+                new MockMultipartFile("qr", "qr", "image/png", "png-bytes".getBytes()));
+
+        assertTrue(Files.exists(root.resolve(key)));
     }
 
     @Test

--- a/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
+++ b/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
@@ -64,6 +64,39 @@ class LocalFileStorageTest {
     }
 
     @Test
+    @DisplayName("공백과 한글이 든 파일명도 업로드 -> URL -> 키 왕복이 성립한다")
+    void roundTripWithSpaceAndHangulFilename(@TempDir Path root) throws IOException {
+        LocalFileStorage sut = storage(root);
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "스크린샷 2025-09-12 오후 7.31.54.png", "image/png", "x".getBytes());
+
+        String key = sut.uploadImage("banner/8", image);
+        String url = sut.getPublicUrl(key);
+
+        // URI 파서를 쓰면 여기서 터진다. 실제 배너 파일명이 이 형태다.
+        assertEquals(key, sut.extractKey(url));
+        assertTrue(Files.exists(root.resolve(key)));
+
+        sut.deleteFile(sut.extractKey(url));
+        assertFalse(Files.exists(root.resolve(key)));
+    }
+
+    @Test
+    @DisplayName("public-base-url이 비어 있으면 기동 시점에 실패한다")
+    void failsFastWhenPublicBaseUrlMissing(@TempDir Path root) {
+        assertThrows(IllegalStateException.class,
+                () -> new LocalFileStorage(root.toString(), "  "));
+    }
+
+    @Test
+    @DisplayName("없는 파일 삭제는 예외 없이 통과한다 (S3 동작과 동일)")
+    void deleteMissingFileIsNoop(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+
+        sut.deleteFile("qr/does-not-exist");
+    }
+
+    @Test
     @DisplayName("루트를 벗어나는 키는 거부한다")
     void rejectsPathTraversal(@TempDir Path root) {
         LocalFileStorage sut = storage(root);

--- a/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
+++ b/src/test/java/side/onetime/infra/storage/LocalFileStorageTest.java
@@ -1,0 +1,90 @@
+package side.onetime.infra.storage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalFileStorageTest {
+
+    private static final String BASE_URL = "https://api.onetime.run/files";
+
+    private LocalFileStorage storage(Path root) {
+        return new LocalFileStorage(root.toString(), BASE_URL);
+    }
+
+    @Test
+    @DisplayName("업로드하면 디렉토리 하위에 키 구조 그대로 저장되고, 그 키로 삭제된다")
+    void uploadAndDelete(@TempDir Path root) throws IOException {
+        LocalFileStorage sut = storage(root);
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "qr.png", "image/png", "hello".getBytes());
+
+        String key = sut.uploadImage("qr", image);
+
+        assertTrue(key.startsWith("qr/"), "키는 디렉토리 접두사를 유지해야 한다: " + key);
+        Path stored = root.resolve(key);
+        assertTrue(Files.exists(stored));
+        assertEquals("hello", Files.readString(stored));
+
+        sut.deleteFile(key);
+        assertFalse(Files.exists(stored));
+    }
+
+    @Test
+    @DisplayName("퍼블릭 URL은 베이스 URL + 키이고, 왕복 변환이 성립한다")
+    void publicUrlRoundTrip(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+        String key = "banner/3/abc_logo.png";
+
+        String url = sut.getPublicUrl(key);
+
+        assertEquals(BASE_URL + "/" + key, url);
+        assertEquals(key, sut.extractKey(url));
+    }
+
+    @Test
+    @DisplayName("마이그레이션 이전에 저장된 S3 형식 URL에서도 키를 추출한다")
+    void extractKeyFromLegacyS3Url(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+
+        String key = sut.extractKey(
+                "https://onetime-bucket.s3.ap-northeast-2.amazonaws.com/banner/3/abc_logo.png");
+
+        assertEquals("banner/3/abc_logo.png", key);
+    }
+
+    @Test
+    @DisplayName("루트를 벗어나는 키는 거부한다")
+    void rejectsPathTraversal(@TempDir Path root) {
+        LocalFileStorage sut = storage(root);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> sut.deleteFile("../../etc/passwd"));
+    }
+
+    @Test
+    @DisplayName("원본 파일명의 경로 구분자는 제거되어 루트를 벗어나지 못한다")
+    void sanitizesOriginalFilename(@TempDir Path root) throws IOException {
+        LocalFileStorage sut = storage(root);
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "../../evil.png", "image/png", "x".getBytes());
+
+        String key = sut.uploadImage("qr", image);
+
+        // 구분자가 사라지면 ".." 는 그냥 파일명의 일부라 상위로 올라가지 못한다
+        assertEquals("qr", key.substring(0, key.indexOf('/')));
+        assertFalse(key.substring(key.indexOf('/') + 1).contains("/"), "키에 하위 경로가 생기면 안 된다: " + key);
+        assertTrue(Files.exists(root.resolve(key)));
+        assertTrue(root.resolve(key).normalize().startsWith(root), "루트를 벗어났다: " + key);
+    }
+}


### PR DESCRIPTION
## 배경

AWS 이탈 마이그레이션 준비 작업입니다. 이미지(QR 5,679개 + 배너 6개, 총 6.9MB)를 S3에서 서버 로컬 디스크로 옮기기 위해, 먼저 저장소를 추상화합니다.

R2 같은 오브젝트 스토리지 대신 로컬 디스크를 고른 이유는 실데이터가 7MB 수준이고, R2 커스텀 도메인은 도메인 존이 Cloudflare에 있어야 하는데 `onetime.run` 은 가비아 NS라 DNS 이전이 선행돼야 하기 때문입니다. 7MB짜리 정적 이미지를 위해 라이브 도메인 DNS를 옮길 값은 아니라고 판단했습니다.

## 변경

- `FileStorage` 인터페이스 도입. 기존 `S3Util` 을 `S3FileStorage` 로 이동 (동작 동일)
- `LocalFileStorage` 추가 — 파일을 `storage.local.root` 에 저장하고 nginx가 정적 서빙
- `storage.type` 프로퍼티로 구현체 선택. **기본값이 `s3` 라 이 PR만으로는 운영 동작이 바뀌지 않습니다**

호출부 8곳은 주입 타입만 `S3Util` → `FileStorage` 로 바뀌었고 로직 변경은 없습니다.

## 왜 기본값을 s3로 두는가

머지 후 컷오버 전까지 운영 배포는 여전히 기존 AWS 서버로 갑니다. 그 서버엔 `/srv/onetime/files` 가 없으므로, 로컬 전용으로 만들면 이미지가 조용히 깨집니다. 두 구현이 전환 기간 동안 공존해야 하고, 그래야 **코드 배포와 인프라 컷오버를 분리**할 수 있습니다. 새 서버에서만 `STORAGE_TYPE=local` 로 띄웁니다.

## 리뷰 반영

품질/보안 리뷰에서 나온 P1 5건을 모두 고쳤습니다.

| | 문제 | 조치 |
|---|---|---|
| P1 | `extractKey` 가 `URI.create` 를 써서 공백·한글 파일명 URL에서 예외. 배너 원본 파일명이 실제로 `"스크린샷 2025-09-12 오후 7.31.54.png"` 형태다. 호출부가 예외를 삼켜서 **기존 배너가 조용히 안 지워짐** | URL 파서 대신 문자열 슬라이싱 |
| P1 | `public-base-url` 이 비면 루트 상대 경로를 반환해 QR/배너 링크가 운영에서만 깨짐 | 기동 시점에 `IllegalStateException` |
| P1 | AWS 자격증명에 빈 기본값을 주면 같은 프로퍼티를 쓰는 `SqsConfig` 때문에 부팅 실패가 런타임 오류로 밀림 | 기본값 원복 (이 PR 범위를 저장소로 한정) |
| P1 | `resolve()` 가 루트 "바깥"만 막아서, 빈 키나 `"x/.."` 가 루트로 정규화되면 통과 → `deleteFile` 이 저장소 디렉토리 자체를 삭제 시도 | 루트 자신도 거부 |
| P1 | 업로드 형식 검증 없음. 로컬 저장소는 API와 **같은 오리진**에서 서빙되므로 svg/html 업로드가 저장형 XSS | content-type + 확장자 허용목록 (`FileStorage.validateImage`) |

## 테스트

`LocalFileStorageTest` 11개 추가. 공백·한글 파일명 왕복, 레거시 S3 URL 파싱, 경로 탈출, 루트 삭제 시도, 비이미지 업로드, 확장자 없는 QR 허용을 덮습니다.

전체 164개 중 163개 통과. `RefreshTokenRepositoryTest::initializationError` 1건 실패는 **이 브랜치 이전 develop에서도 동일하게 실패**하는 기존 이슈입니다 (stash 후 재현 확인).

## 서버 측 (별도, 이 PR 아님)

새 서버의 nginx는 `/files/` 를 `nosniff` + `CSP sandbox` 헤더와 함께 서빙하고 `svg|html|js|php` 는 403 처리합니다. QR은 확장자가 없어 `default_type image/png` 를 지정했습니다 (안 하면 `application/octet-stream` 으로 나가 이미지가 표시되지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이미지와 QR 코드를 AWS S3 또는 서버 로컬 디스크에 저장할 수 있습니다.
  * 저장소 유형, 로컬 저장 경로, 공개 URL을 환경 설정으로 선택할 수 있습니다.
  * 이미지 업로드 시 지원 형식과 확장자를 자동 검증합니다.
  * 로컬 저장소에서도 이미지 조회, 삭제, 공개 URL 변환을 지원합니다.

* **문서**
  * 저장소 구성 방식과 관련 환경 변수 설정 방법을 추가했습니다.

* **버그 수정**
  * 파일명에 포함된 경로 구분자와 경로 순회로 인한 파일 접근 문제를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->